### PR TITLE
Create entity for accounts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ publish = false
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+getset = "0.1.2"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/src/account/account_id.rs
+++ b/src/account/account_id.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Account id
+///
+/// GitHub assigns a unique `id` to each account that cannot be changed. The `id` is used to
+/// interact with resources in GitHub's REST API.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct AccountId(u64);
+
+impl AccountId {
+    /// Initializes a new account id.
+    pub fn new(account_id: u64) -> Self {
+        Self(account_id)
+    }
+
+    /// Returns the account id.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for AccountId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AccountId;
+
+    #[test]
+    fn trait_display() {
+        let id = AccountId::new(1);
+
+        assert_eq!("1", id.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AccountId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AccountId>();
+    }
+}

--- a/src/account/account_type.rs
+++ b/src/account/account_type.rs
@@ -1,0 +1,49 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// GitHub account type
+///
+/// Accounts can represent either an organization or a user.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub enum AccountType {
+    /// Organization account
+    Organization,
+
+    /// User account
+    User,
+}
+
+impl Display for AccountType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            AccountType::Organization => "Organization",
+            AccountType::User => "User",
+        };
+
+        write!(f, "{}", string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AccountType;
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("Organization", AccountType::Organization.to_string());
+        assert_eq!("User", AccountType::User.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<AccountType>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<AccountType>();
+    }
+}

--- a/src/account/login.rs
+++ b/src/account/login.rs
@@ -1,0 +1,61 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Login or account name
+///
+/// Every account on GitHub is uniquely identified by its `login`, which is the name of the account.
+/// Users can rename accounts, but the account's `id` and `node_id` always stays the same.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct Login(String);
+
+impl Login {
+    /// Initializes a new login.
+    pub fn new(login: impl Into<String>) -> Self {
+        Self(login.into())
+    }
+
+    /// Returns a string representation of the login.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use github_parts::account::Login;
+    ///
+    /// let login = Login::new("login");
+    /// assert_eq!("login", login.get());
+    /// ```
+    pub fn get(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Login {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Login;
+
+    #[test]
+    fn trait_display() {
+        let login = Login::new("login");
+
+        assert_eq!("login", login.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Login>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Login>();
+    }
+}

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,0 +1,88 @@
+//! GitHub account
+//!
+//! Repositories hosted on GitHub belong to an account, which can be either an organization or a
+//! user. Accounts have various unique properties such as a `login` and an `id` that are used to
+//! identify and interact with them.
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+pub use self::account_id::AccountId;
+pub use self::account_type::AccountType;
+pub use self::login::Login;
+
+mod account_id;
+mod account_type;
+mod login;
+
+/// GitHub account
+///
+/// An account on GitHub can represent either an organization or a user. Accounts have a unique `id`
+/// that is used throughout GitHub's REST API to identify accounts. They also have a `login`, which
+/// is a human-readable name that must be unique, but can be changed by the owner.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+)]
+pub struct Account {
+    /// Returns the login of the account.
+    #[getset(get = "pub")]
+    login: Login,
+
+    /// Returns the id of the account.
+    #[getset(get_copy = "pub")]
+    id: AccountId,
+
+    /// Returns the type of the account.
+    #[getset(get_copy = "pub")]
+    #[serde(rename = "type")]
+    account_type: AccountType,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Account, AccountType};
+
+    #[test]
+    fn trait_deserialize() {
+        let json = r#"
+        {
+            "login": "octocat",
+            "id": 1,
+            "node_id": "MDQ6VXNlcjE=",
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+        }
+        "#;
+
+        let account: Account = serde_json::from_str(json).unwrap();
+
+        assert_eq!(1, account.id().get());
+        assert_eq!("octocat", account.login().get());
+        assert!(matches!(account.account_type(), AccountType::User));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Account>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Account>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@
 
 #![warn(missing_docs)]
 
+pub mod account;
 pub mod event;


### PR DESCRIPTION
A new struct has been created that represents an account on GitHub. Accounts have a unique id that is used with GitHub's REST API, and a human-readable login that is used on the website.