### PR TITLE
Create entity for repositories

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -6,6 +6,7 @@
 
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
 
 pub use self::account_id::AccountId;
 pub use self::account_type::AccountType;
@@ -38,9 +39,27 @@ pub struct Account {
     account_type: AccountType,
 }
 
+impl Account {
+    /// Initializes a new account.
+    pub fn new(login: Login, id: AccountId, account_type: AccountType) -> Self {
+        Self {
+            login,
+            id,
+            account_type,
+        }
+    }
+}
+
+impl Display for Account {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.login.get())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Account, AccountType};
+    use crate::account::{AccountId, Login};
 
     #[test]
     fn trait_deserialize() {
@@ -72,6 +91,17 @@ mod tests {
         assert_eq!(1, account.id().get());
         assert_eq!("octocat", account.login().get());
         assert!(matches!(account.account_type(), AccountType::User));
+    }
+
+    #[test]
+    fn trait_display() {
+        let account = Account::new(
+            Login::new("devxbots"),
+            AccountId::new(104442885),
+            AccountType::Organization,
+        );
+
+        assert_eq!("devxbots", account.to_string());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,5 @@
 
 pub mod account;
 pub mod event;
+pub mod repository;
+pub mod visibility;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,0 +1,127 @@
+//! Repository
+//!
+//! Repositories store source code using the Git version control system. They are the core resource
+//! on GitHub, and almost everything else is organized around them.
+
+use std::fmt::{Display, Formatter};
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+use crate::account::Account;
+use crate::visibility::Visibility;
+
+pub use self::repository_id::RepositoryId;
+pub use self::repository_name::RepositoryName;
+
+mod repository_id;
+mod repository_name;
+
+/// Repository
+///
+/// Repositories are uniquely identified by the combination of their `owner` and `name`. They have
+/// a `id` that never changes, even if the repository is renamed, and a `visibility` that indicates
+/// whether the repository is public or private.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+)]
+pub struct Repository {
+    /// Returns the id of the repository.
+    #[getset(get_copy = "pub")]
+    id: RepositoryId,
+
+    /// Returns the name of the repository.
+    #[getset(get = "pub")]
+    name: RepositoryName,
+
+    /// Returns the description of the repository.
+    #[getset(get = "pub")]
+    description: String,
+
+    /// Returns the owner of the repository.
+    #[getset(get = "pub")]
+    owner: Account,
+
+    /// Returns the visibility of the repository.
+    #[getset(get_copy = "pub")]
+    visibility: Visibility,
+}
+
+impl Repository {
+    /// Initializes a new repository.
+    pub fn new(
+        id: RepositoryId,
+        name: RepositoryName,
+        description: String,
+        owner: Account,
+        visibility: Visibility,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            description,
+            owner,
+            visibility,
+        }
+    }
+
+    /// Returns the full name of the repository.
+    ///
+    /// The full name of a repository is the combination of the owner's login and the repository's
+    /// name. This combination can be used to uniquely identify a repository on GitHub, and is thus
+    /// often used to reference them externally.
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner.login(), self.name())
+    }
+}
+
+impl Display for Repository {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.full_name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::account::{Account, AccountId, AccountType, Login};
+    use crate::repository::{RepositoryId, RepositoryName};
+    use crate::visibility::Visibility;
+
+    use super::Repository;
+
+    fn repository() -> Repository {
+        Repository::new(
+            RepositoryId::new(496534847),
+            RepositoryName::new("github-parts"),
+            "🔩 Types and actions to interact with GitHub".into(),
+            Account::new(
+                Login::new("devxbots"),
+                AccountId::new(104442885),
+                AccountType::Organization,
+            ),
+            Visibility::Public,
+        )
+    }
+
+    #[test]
+    fn full_name() {
+        assert_eq!("devxbots/github-parts", repository().full_name());
+    }
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("devxbots/github-parts", repository().to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Repository>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Repository>();
+    }
+}

--- a/src/repository/repository_id.rs
+++ b/src/repository/repository_id.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Repository id
+///
+/// GitHub assigns a unique `id` to each repository that cannot be changed. The `id` is used to
+/// interact with resources in GitHub's REST API.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct RepositoryId(u64);
+
+impl RepositoryId {
+    /// Initializes a new repository id.
+    pub fn new(repository_id: u64) -> Self {
+        Self(repository_id)
+    }
+
+    /// Returns the repository id.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for RepositoryId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RepositoryId;
+
+    #[test]
+    fn trait_display() {
+        let id = RepositoryId::new(1);
+
+        assert_eq!("1", id.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RepositoryId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<RepositoryId>();
+    }
+}

--- a/src/repository/repository_name.rs
+++ b/src/repository/repository_name.rs
@@ -1,0 +1,62 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Repository name
+///
+/// Repositories on GitHub are uniquely identified by the combination of their `owner` and `name`.
+/// The repository name can be any string, but it has to be unique for its owner. Repositories can
+/// be renamed at any time.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct RepositoryName(String);
+
+impl RepositoryName {
+    /// Initializes a new repository name.
+    pub fn new(repository_name: impl Into<String>) -> Self {
+        Self(repository_name.into())
+    }
+
+    /// Returns a string representation of the repository name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use github_parts::repository::RepositoryName;
+    ///
+    /// let repository_name = RepositoryName::new("repository_name");
+    /// assert_eq!("repository_name", repository_name.get());
+    /// ```
+    pub fn get(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for RepositoryName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RepositoryName;
+
+    #[test]
+    fn trait_display() {
+        let repository_name = RepositoryName::new("repository_name");
+
+        assert_eq!("repository_name", repository_name.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<RepositoryName>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<RepositoryName>();
+    }
+}

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,0 +1,57 @@
+//! Visibility
+//!
+//! Many resources on GitHub can either be public or private, which is called their visibility.
+//! Private resources are only accessible to the owner, team members, or collaborators. Public
+//! resources can be seen by anyone.
+
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Visibility
+///
+/// Many resources on GitHub can either be public or private, which is called their visibility.
+/// Private resources are only accessible to the owner, team members, or collaborators. Public
+/// resources can be seen by anyone.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub enum Visibility {
+    /// Only visible to the owner, team members, and collaborators
+    Private,
+
+    /// Visible to everyone
+    Public,
+}
+
+impl Display for Visibility {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            Visibility::Private => "private",
+            Visibility::Public => "public",
+        };
+
+        write!(f, "{}", string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Visibility;
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("private", Visibility::Private.to_string());
+        assert_eq!("public", Visibility::Public.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Visibility>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Visibility>();
+    }
+}


### PR DESCRIPTION
Repositories are the core resource on GitHub, and almost everything else is organized around them. A new entity with a minimal set of fields has been created to represent them.