### PR TITLE
Create entity for check runs

### DIFF
--- a/src/check_run/check_run_conclusion.rs
+++ b/src/check_run/check_run_conclusion.rs
@@ -1,0 +1,77 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Check run conclusion
+///
+/// When a check run finishes, its result is indicated by the `conclusion`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub enum CheckRunConclusion {
+    /// The check run finished successfully.
+    Success,
+
+    /// The check run failed.
+    Failure,
+
+    /// The check run finished without a conclusion.
+    Neutral,
+
+    /// The check run was cancelled.
+    Cancelled,
+
+    /// The check run timed out.
+    TimedOut,
+
+    /// The check run requires an action by the user.
+    ActionRequired,
+
+    /// The check run is stale.
+    Stale,
+}
+
+impl Display for CheckRunConclusion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            CheckRunConclusion::Success => "success",
+            CheckRunConclusion::Failure => "failure",
+            CheckRunConclusion::Neutral => "neutral",
+            CheckRunConclusion::Cancelled => "cancelled",
+            CheckRunConclusion::TimedOut => "timed out",
+            CheckRunConclusion::ActionRequired => "action required",
+            CheckRunConclusion::Stale => "stale",
+        };
+
+        write!(f, "{}", string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunConclusion;
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("success", CheckRunConclusion::Success.to_string());
+        assert_eq!("failure", CheckRunConclusion::Failure.to_string());
+        assert_eq!("neutral", CheckRunConclusion::Neutral.to_string());
+        assert_eq!("cancelled", CheckRunConclusion::Cancelled.to_string());
+        assert_eq!("timed out", CheckRunConclusion::TimedOut.to_string());
+        assert_eq!(
+            "action required",
+            CheckRunConclusion::ActionRequired.to_string()
+        );
+        assert_eq!("stale", CheckRunConclusion::Stale.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunConclusion>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunConclusion>();
+    }
+}

--- a/src/check_run/check_run_id.rs
+++ b/src/check_run/check_run_id.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Check run id
+///
+/// Check runs are uniquely identified by their `id`, which can be used to interact with a check run
+/// in GitHub's REST API.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct CheckRunId(u64);
+
+impl CheckRunId {
+    /// Initializes a new check run id.
+    pub fn new(check_run_id: u64) -> Self {
+        Self(check_run_id)
+    }
+
+    /// Returns the check run id.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for CheckRunId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunId;
+
+    #[test]
+    fn trait_display() {
+        let id = CheckRunId::new(1);
+
+        assert_eq!("1", id.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunId>();
+    }
+}

--- a/src/check_run/check_run_name.rs
+++ b/src/check_run/check_run_name.rs
@@ -1,0 +1,61 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Check run name
+///
+/// Check runs have a `name` that describes them and their purpose. The name is set by the app or
+/// integration when the check run is created.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct CheckRunName(String);
+
+impl CheckRunName {
+    /// Initializes a new check run name.
+    pub fn new(check_run_name: impl Into<String>) -> Self {
+        Self(check_run_name.into())
+    }
+
+    /// Returns a string representation of the check run name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use github_parts::check_run::CheckRunName;
+    ///
+    /// let check_run_name = CheckRunName::new("check_run_name");
+    /// assert_eq!("check_run_name", check_run_name.get());
+    /// ```
+    pub fn get(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for CheckRunName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunName;
+
+    #[test]
+    fn trait_display() {
+        let check_run_name = CheckRunName::new("check_run_name");
+
+        assert_eq!("check_run_name", check_run_name.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunName>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunName>();
+    }
+}

--- a/src/check_run/check_run_status.rs
+++ b/src/check_run/check_run_status.rs
@@ -1,0 +1,55 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Check run status
+///
+/// Check runs have a status, which indicates whether the check run has already started, is
+/// currently running, or has finished.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub enum CheckRunStatus {
+    /// The check run has been queued, but not started yet.
+    Queued,
+
+    /// The check run is currently running.
+    InProgress,
+
+    /// The check run has finished.
+    Completed,
+}
+
+impl Display for CheckRunStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let string = match self {
+            CheckRunStatus::Queued => "queued",
+            CheckRunStatus::InProgress => "in progress",
+            CheckRunStatus::Completed => "completed",
+        };
+
+        write!(f, "{}", string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunStatus;
+
+    #[test]
+    fn trait_display() {
+        assert_eq!("queued", CheckRunStatus::Queued.to_string());
+        assert_eq!("in progress", CheckRunStatus::InProgress.to_string());
+        assert_eq!("completed", CheckRunStatus::Completed.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunStatus>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunStatus>();
+    }
+}

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -1,0 +1,64 @@
+//! Check run
+//!
+//! When code is pushed to GitHub, apps and integrations can start check runs to perform arbitrary
+//! tasks, e.g. run tests or perform static analysis.
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+pub use self::check_run_conclusion::CheckRunConclusion;
+pub use self::check_run_id::CheckRunId;
+pub use self::check_run_name::CheckRunName;
+pub use self::check_run_status::CheckRunStatus;
+
+mod check_run_conclusion;
+mod check_run_id;
+mod check_run_name;
+mod check_run_status;
+
+/// Check run
+///
+/// When code is pushed to GitHub, apps and integrations can start check runs to perform arbitrary
+/// tasks, e.g. run tests or perform static analysis. These check runs end with a conclusion that
+/// informs the user about the success or failure of the task.
+///
+/// The `conclusion` of a check run is only available when the check run has been completed.
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+)]
+pub struct CheckRun {
+    /// Returns the unique id of the check run.
+    #[getset(get_copy = "pub")]
+    id: CheckRunId,
+
+    /// Returns the name of the check run.
+    #[getset(get = "pub")]
+    name: CheckRunName,
+
+    /// Returns the status of the check run.
+    #[getset(get_copy = "pub")]
+    status: CheckRunStatus,
+
+    /// Returns the conclusion of the check run.
+    ///
+    /// The conclusion is only set when the status of the check run is `completed`.
+    #[getset(get_copy = "pub")]
+    conclusion: Option<CheckRunConclusion>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRun;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRun>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRun>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![warn(missing_docs)]
 
 pub mod account;
+pub mod check_run;
 pub mod event;
 pub mod repository;
 pub mod visibility;


### PR DESCRIPTION
Check runs are arbitrary tasks that apps and integrations can run when code is pushed to GitHub. They end with a conclusion, which notifies the user of the success or failure of the task.