### PR TITLE
Create entity for installations

### DIFF
--- a/src/installation/installation_id.rs
+++ b/src/installation/installation_id.rs
@@ -1,0 +1,53 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+/// Installation id
+///
+/// When a GitHub App is added to a repository, it's called an installation. Each installation has a
+/// unique `id` that can be used by the GitHub App to authenticate and interact with a specific
+/// repository.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
+pub struct InstallationId(u64);
+
+impl InstallationId {
+    /// Initializes a new installation id.
+    pub fn new(installation_id: u64) -> Self {
+        Self(installation_id)
+    }
+
+    /// Returns the installation id.
+    pub fn get(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for InstallationId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstallationId;
+
+    #[test]
+    fn trait_display() {
+        let id = InstallationId::new(1);
+
+        assert_eq!("1", id.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<InstallationId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<InstallationId>();
+    }
+}

--- a/src/installation/mod.rs
+++ b/src/installation/mod.rs
@@ -1,0 +1,65 @@
+//! Installation
+//!
+//! When a GitHub App is added to a repository, it's called an installation.
+
+use std::fmt::{Display, Formatter};
+
+use getset::CopyGetters;
+use serde::{Deserialize, Serialize};
+
+pub use self::installation_id::InstallationId;
+
+mod installation_id;
+
+/// Installation
+///
+/// When a GitHub App is added to a repository, it's called an installation. Each installation has a
+/// unique `id` that can be used by the GitHub App to authenticate and interact with a specific
+/// repository.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
+)]
+pub struct Installation {
+    /// Returns the installation id.
+    #[getset(get_copy = "pub")]
+    id: InstallationId,
+}
+
+impl Installation {
+    /// Initializes a new installation.
+    pub fn new(id: InstallationId) -> Self {
+        Self { id }
+    }
+}
+
+impl Display for Installation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::installation::InstallationId;
+
+    use super::Installation;
+
+    #[test]
+    fn trait_display() {
+        let installation = Installation::new(InstallationId::new(1));
+
+        assert_eq!("1", installation.to_string());
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<Installation>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<Installation>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,6 @@
 pub mod account;
 pub mod check_run;
 pub mod event;
+pub mod installation;
 pub mod repository;
 pub mod visibility;


### PR DESCRIPTION
When a GitHub App is added to a repository, it is called an installation. Installations have a unique id, which can be used by the app to authenticate and interact with the specific repository.