### PR TITLE
Enable automatic dependency updates for Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,16 @@ updates:
       - C-dependency
       - L-github
       - R-ignore
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    assignees:
+      - jdno
+    reviewers:
+      - jdno
+    labels:
+      - C-dependency
+      - L-rust
+      - R-ignore


### PR DESCRIPTION
Dependabot has been configured for Rust so that we get automatic updates for our dependencies.