### PR TITLE
Create action to get a file from GitHub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+base64 = "0.13.0"
 chrono = "0.4.19"
 getset = "0.1.2"
 jsonwebtoken = "8.1.0"
@@ -34,4 +35,4 @@ thiserror = "1.0.31"
 
 [dev-dependencies]
 mockito = "0.31.0"
-tokio = { version = "1.19.2", features = ["macros", "rt"] }
+tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread"] }

--- a/src/action/get_file/error.rs
+++ b/src/action/get_file/error.rs
@@ -1,0 +1,62 @@
+use base64::DecodeError;
+use thiserror::Error;
+
+use crate::error::Error;
+
+/// Errors that can occur when getting a file from GitHub
+#[derive(Debug, Error)]
+pub enum GetFileError {
+    /// An invalid argument was passed to the action
+    #[error("argument was invalid. {0}")]
+    Argument(String),
+
+    /// Authenticating with GitHub failed
+    #[error("authentication failed. {0}")]
+    Authentication(#[from] Error),
+
+    /// Decoding the file's content failed
+    #[error("decoding content failed. {0}")]
+    Decoding(#[from] DecodeError),
+
+    /// The user tried to get a directory
+    #[error("path was a directory, but must be a file")]
+    Directory,
+
+    /// The file encoding is not supported by the crate
+    #[error("encoding {0} is not supported")]
+    Encoding(String),
+
+    /// The outgoing request to GitHub failed
+    #[error("querying the content failed. {0}")]
+    Request(#[from] reqwest::Error),
+
+    /// Deserializing the payload in the API response failed
+    #[error("response could not be deserialized. {0}")]
+    Response(#[from] serde_json::Error),
+
+    /// The user tried to get a git submodule
+    #[error("path was a submodule, but must be a file")]
+    Submodule,
+
+    /// The user tried to get a symlink
+    // TODO: Follow symlinks and return the file
+    #[error("path was a symlink, but must be a file")]
+    Symlink,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetFileError;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GetFileError>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GetFileError>();
+    }
+}

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -1,0 +1,268 @@
+//! Get a file from a repository on GitHub
+
+use std::path::Path;
+
+use reqwest::Client;
+
+use crate::account::Login;
+use crate::github::token::{AppToken, InstallationToken};
+use crate::github::{AppId, GitHubHost, PrivateKey};
+use crate::installation::InstallationId;
+use crate::repository::RepositoryName;
+
+pub use self::error::GetFileError;
+use self::payload::GetFilePayload;
+pub use self::result::GetFileResult;
+
+mod error;
+mod payload;
+mod result;
+
+/// Get a file
+///
+/// This action downloads a file from GitHub.
+pub async fn get_file(
+    github_host: &GitHubHost,
+    app_id: &AppId,
+    private_key: &PrivateKey,
+    installation: &InstallationId,
+    owner: &Login,
+    repository: &RepositoryName,
+    path: &Path,
+) -> Result<GetFileResult, GetFileError> {
+    let url = format!(
+        "{}/repos/{}/{}/contents/{}",
+        github_host.get(),
+        owner.get(),
+        repository.get(),
+        path.to_str()
+            .ok_or_else(|| GetFileError::Argument("failed to convert path to string".into()))?
+    );
+
+    let app_token = AppToken::new(app_id, private_key)?;
+    let installation_token = InstallationToken::new(github_host, &app_token, installation).await?;
+
+    let body = Client::new()
+        .get(url)
+        .header(
+            "Authorization",
+            format!("Bearer {}", installation_token.get()),
+        )
+        .header("Accept", "application/vnd.github.v3+json")
+        .header("User-Agent", "devxbots/github-parts")
+        .send()
+        .await?
+        .json::<serde_json::Value>()
+        .await?;
+
+    if body.is_array() {
+        Err(GetFileError::Directory)
+    } else {
+        let payload: GetFilePayload = serde_json::from_value(body)?;
+        GetFileResult::try_from(payload)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use mockito::mock;
+
+    use crate::account::Login;
+    use crate::action::get_file::{get_file, GetFileError};
+    use crate::github::{AppId, GitHubHost, PrivateKey};
+    use crate::installation::InstallationId;
+    use crate::repository::RepositoryName;
+
+    #[tokio::test]
+    async fn get_file_with_file() {
+        let _token_mock = mock("POST", "/app/installations/1/access_tokens")
+            .with_status(200)
+            .with_body(r#"{ "token": "ghs_16C7e42F292c6912E7710c838347Ae178B4a" }"#)
+            .create();
+        let _content_mock = mock("GET", "/repos/octokit/octokit.rb/contents/README.md")
+            .with_status(200)
+            .with_body(r#"
+                {
+                  "type": "file",
+                  "encoding": "base64",
+                  "size": 5362,
+                  "name": "README.md",
+                  "path": "README.md",
+                  "content": "ZW5jb2RlZCBjb250ZW50IC4uLg==",
+                  "sha": "3d21ec53a331a6f037a91c368710b99387d012c1",
+                  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+                  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+                  "html_url": "https://github.com/octokit/octokit.rb/blob/master/README.md",
+                  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/README.md",
+                  "_links": {
+                    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/3d21ec53a331a6f037a91c368710b99387d012c1",
+                    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/README.md",
+                    "html": "https://github.com/octokit/octokit.rb/blob/master/README.md"
+                  }
+                }
+            "#).create();
+
+        let file = get_file(
+            &GitHubHost::new(mockito::server_url()),
+            &AppId::new(1),
+            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            &InstallationId::new(1),
+            &Login::new("octokit"),
+            &RepositoryName::new("octokit.rb"),
+            PathBuf::from("README.md").as_path(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!("README.md", file.name());
+        assert_eq!(5362, file.size());
+    }
+
+    #[tokio::test]
+    async fn get_file_with_directory() {
+        let _token_mock = mock("POST", "/app/installations/1/access_tokens")
+            .with_status(200)
+            .with_body(r#"{ "token": "ghs_16C7e42F292c6912E7710c838347Ae178B4a" }"#)
+            .create();
+        let _content_mock = mock("GET", "/repos/octokit/octokit.rb/contents/lib/octokit")
+            .with_status(200)
+            .with_body(r#"
+                [
+                  {
+                    "type": "file",
+                    "size": 625,
+                    "name": "octokit.rb",
+                    "path": "lib/octokit.rb",
+                    "sha": "fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                    "url": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit.rb",
+                    "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                    "html_url": "https://github.com/octokit/octokit.rb/blob/master/lib/octokit.rb",
+                    "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/lib/octokit.rb",
+                    "_links": {
+                      "self": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit.rb",
+                      "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/fff6fe3a23bf1c8ea0692b4a883af99bee26fd3b",
+                      "html": "https://github.com/octokit/octokit.rb/blob/master/lib/octokit.rb"
+                    }
+                  },
+                  {
+                    "type": "dir",
+                    "size": 0,
+                    "name": "octokit",
+                    "path": "lib/octokit",
+                    "sha": "a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                    "url": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit",
+                    "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/trees/a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                    "html_url": "https://github.com/octokit/octokit.rb/tree/master/lib/octokit",
+                    "download_url": null,
+                    "_links": {
+                      "self": "https://api.github.com/repos/octokit/octokit.rb/contents/lib/octokit",
+                      "git": "https://api.github.com/repos/octokit/octokit.rb/git/trees/a84d88e7554fc1fa21bcbc4efae3c782a70d2b9d",
+                      "html": "https://github.com/octokit/octokit.rb/tree/master/lib/octokit"
+                    }
+                  }
+                ]
+            "#).create();
+
+        let error = get_file(
+            &GitHubHost::new(mockito::server_url()),
+            &AppId::new(1),
+            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            &InstallationId::new(1),
+            &Login::new("octokit"),
+            &RepositoryName::new("octokit.rb"),
+            PathBuf::from("lib/octokit").as_path(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, GetFileError::Directory));
+    }
+
+    #[tokio::test]
+    async fn get_file_with_symlink() {
+        let _token_mock = mock("POST", "/app/installations/1/access_tokens")
+            .with_status(200)
+            .with_body(r#"{ "token": "ghs_16C7e42F292c6912E7710c838347Ae178B4a" }"#)
+            .create();
+        let _content_mock = mock("GET", "/repos/octokit/octokit.rb/contents/bin/some-symlink")
+            .with_status(200)
+            .with_body(r#"
+                {
+                  "type": "symlink",
+                  "target": "/path/to/symlink/target",
+                  "size": 23,
+                  "name": "some-symlink",
+                  "path": "bin/some-symlink",
+                  "sha": "452a98979c88e093d682cab404a3ec82babebb48",
+                  "url": "https://api.github.com/repos/octokit/octokit.rb/contents/bin/some-symlink",
+                  "git_url": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/452a98979c88e093d682cab404a3ec82babebb48",
+                  "html_url": "https://github.com/octokit/octokit.rb/blob/master/bin/some-symlink",
+                  "download_url": "https://raw.githubusercontent.com/octokit/octokit.rb/master/bin/some-symlink",
+                  "_links": {
+                    "git": "https://api.github.com/repos/octokit/octokit.rb/git/blobs/452a98979c88e093d682cab404a3ec82babebb48",
+                    "self": "https://api.github.com/repos/octokit/octokit.rb/contents/bin/some-symlink",
+                    "html": "https://github.com/octokit/octokit.rb/blob/master/bin/some-symlink"
+                  }
+                }
+            "#).create();
+
+        let error = get_file(
+            &GitHubHost::new(mockito::server_url()),
+            &AppId::new(1),
+            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            &InstallationId::new(1),
+            &Login::new("octokit"),
+            &RepositoryName::new("octokit.rb"),
+            PathBuf::from("bin/some-symlink").as_path(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, GetFileError::Symlink));
+    }
+
+    #[tokio::test]
+    async fn get_file_with_submodule() {
+        let _token_mock = mock("POST", "/app/installations/1/access_tokens")
+            .with_status(200)
+            .with_body(r#"{ "token": "ghs_16C7e42F292c6912E7710c838347Ae178B4a" }"#)
+            .create();
+        let _content_mock = mock("GET", "/repos/jquery/jquery/contents/test/qunit")
+            .with_status(200)
+            .with_body(r#"
+                {
+                  "type": "submodule",
+                  "submodule_git_url": "git://github.com/jquery/qunit.git",
+                  "size": 0,
+                  "name": "qunit",
+                  "path": "test/qunit",
+                  "sha": "6ca3721222109997540bd6d9ccd396902e0ad2f9",
+                  "url": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+                  "git_url": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+                  "html_url": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+                  "download_url": null,
+                  "_links": {
+                    "git": "https://api.github.com/repos/jquery/qunit/git/trees/6ca3721222109997540bd6d9ccd396902e0ad2f9",
+                    "self": "https://api.github.com/repos/jquery/jquery/contents/test/qunit?ref=master",
+                    "html": "https://github.com/jquery/qunit/tree/6ca3721222109997540bd6d9ccd396902e0ad2f9"
+                  }
+                }
+            "#).create();
+
+        let error = get_file(
+            &GitHubHost::new(mockito::server_url()),
+            &AppId::new(1),
+            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            &InstallationId::new(1),
+            &Login::new("jquery"),
+            &RepositoryName::new("jquery"),
+            PathBuf::from("test/qunit").as_path(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, GetFileError::Submodule));
+    }
+}

--- a/src/action/get_file/payload.rs
+++ b/src/action/get_file/payload.rs
@@ -1,0 +1,119 @@
+use base64::decode;
+use serde::Deserialize;
+
+use crate::action::get_file::{GetFileError, GetFileResult};
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum GetFilePayload {
+    Directory,
+    File(FilePayload),
+    Submodule,
+    Symlink,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+pub struct FilePayload {
+    encoding: FileEncoding,
+    size: u64,
+    name: String,
+    path: String,
+    content: String,
+    sha: String,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileEncoding {
+    Base64,
+}
+
+impl TryFrom<GetFilePayload> for GetFileResult {
+    type Error = GetFileError;
+
+    fn try_from(value: GetFilePayload) -> Result<Self, Self::Error> {
+        let payload = match value {
+            GetFilePayload::Directory => Err(GetFileError::Directory),
+            GetFilePayload::File(payload) => Ok(payload),
+            GetFilePayload::Submodule => Err(GetFileError::Submodule),
+            GetFilePayload::Symlink => Err(GetFileError::Symlink),
+        }?;
+
+        let sanitized_content = &payload.content.replace('\n', "");
+        let content = decode(sanitized_content)?;
+
+        Ok(GetFileResult {
+            size: payload.size,
+            name: payload.name,
+            path: payload.path.into(),
+            sha: payload.sha,
+            content,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FileEncoding, FilePayload, GetFilePayload};
+    use crate::action::get_file::GetFileResult;
+
+    const PAYLOAD: &str = r#"
+        {
+          "name": "README.md",
+          "path": "README.md",
+          "sha": "3928ebd3c7db689f5ea5b11db6bfa89b132139c3",
+          "size": 1012,
+          "url": "https://api.github.com/repos/devxbots/github-parts/contents/README.md?ref=main",
+          "html_url": "https://github.com/devxbots/github-parts/blob/main/README.md",
+          "git_url": "https://api.github.com/repos/devxbots/github-parts/git/blobs/3928ebd3c7db689f5ea5b11db6bfa89b132139c3",
+          "download_url": "https://raw.githubusercontent.com/devxbots/github-parts/main/README.md",
+          "type": "file",
+          "content": "IyDwn5SpIGdpdGh1Yi1wYXJ0cwoKYGdpdGh1Yi1wYXJ0c2AgaXMgYW4gb3Bp\nbmlvbmF0ZWQgaW50ZWdyYXRpb24gd2l0aCB0aGUgR2l0SHViIHBsYXRmb3Jt\nLCB1c2VkIGJ5CltERVYgeCBCT1RTXSBmb3IgaXRzIGF1dG9tYXRpb25zLiBJ\ndCBjb250YWlucyBfdHlwZXNfIGZvciB0aGUgcmVzb3VyY2VzIHByb3ZpZGVk\nCmJ5IEdpdEh1YiB0aHJvdWdoIGl0cyBBUEksIGFuZCBfYWN0aW9uc18gdGhh\ndCBjYW4gaW50ZXJhY3Qgd2l0aCB0aGUgcGxhdGZvcm0gaW4KdmFyaW91cyB3\nYXlzLgoKIyMgU3RhdHVzCgpXZSBhcmUgYWN0aXZlbHkgZGV2ZWxvcGluZyBg\nZ2l0aHViLXBhcnRzYC4gSXRzIEFQSSBhbmQgZnVuY3Rpb25hbGl0eSBhcmUg\nbm90CnN0YWJsZSBhbmQgY2FuIGNoYW5nZSBhdCBhbnkgdGltZS4gRHVyaW5n\nIHRoaXMgcGVyaW9kLCB3ZSBkb24ndCBhY2NlcHQgY29kZQpjb250cmlidXRp\nb25zIHRvIHRoZSBwcm9qZWN0LgoKIyMgTGljZW5zZQoKTGljZW5zZWQgdW5k\nZXIgZWl0aGVyIG9mCgotIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAo\nW0xJQ0VOU0UtQVBBQ0hFXShMSUNFTlNFLUFQQUNIRSkgb3IgPGh0dHA6Ly93\nd3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMD4pCi0gTUlUIGxp\nY2Vuc2UgKFtMSUNFTlNFLU1JVF0oTElDRU5TRS1NSVQpIG9yIDxodHRwOi8v\nb3BlbnNvdXJjZS5vcmcvbGljZW5zZXMvTUlUPikKCmF0IHlvdXIgb3B0aW9u\nLgoKIyMgQ29udHJpYnV0aW9uCgpVbmxlc3MgeW91IGV4cGxpY2l0bHkgc3Rh\ndGUgb3RoZXJ3aXNlLCBhbnkgY29udHJpYnV0aW9uIGludGVudGlvbmFsbHkg\nc3VibWl0dGVkCmZvciBpbmNsdXNpb24gaW4gdGhlIHdvcmsgYnkgeW91LCBh\ncyBkZWZpbmVkIGluIHRoZSBBcGFjaGUtMi4wIGxpY2Vuc2UsIHNoYWxsIGJl\nCmR1YWwgbGljZW5zZWQgYXMgYWJvdmUsIHdpdGhvdXQgYW55IGFkZGl0aW9u\nYWwgdGVybXMgb3IgY29uZGl0aW9ucy4KCltkZXYgeCBib3RzXTogaHR0cHM6\nLy9naXRodWIuY29tL2Rldnhib3RzCg==\n",
+          "encoding": "base64",
+          "_links": {
+            "self": "https://api.github.com/repos/devxbots/github-parts/contents/README.md?ref=main",
+            "git": "https://api.github.com/repos/devxbots/github-parts/git/blobs/3928ebd3c7db689f5ea5b11db6bfa89b132139c3",
+            "html": "https://github.com/devxbots/github-parts/blob/main/README.md"
+          }
+        }
+    "#;
+
+    #[test]
+    fn trait_deserialize() {
+        let payload: GetFilePayload = serde_json::from_str(PAYLOAD).unwrap();
+
+        assert!(matches!(payload, GetFilePayload::File(_)));
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GetFilePayload>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GetFilePayload>();
+    }
+
+    #[test]
+    fn trait_try_from() {
+        let payload = GetFilePayload::File(FilePayload {
+            encoding: FileEncoding::Base64,
+            size: 1012,
+            name: "README.md".to_string(),
+            path: "README.md".to_string(),
+            content: "IyDwn5SpIGdpdGh1Yi1wYXJ0cwoKYGdpdGh1Yi1wYXJ0c2AgaXMgYW4gb3Bp\nbmlvbmF0ZWQgaW50ZWdyYXRpb24gd2l0aCB0aGUgR2l0SHViIHBsYXRmb3Jt\nLCB1c2VkIGJ5CltERVYgeCBCT1RTXSBmb3IgaXRzIGF1dG9tYXRpb25zLiBJ\ndCBjb250YWlucyBfdHlwZXNfIGZvciB0aGUgcmVzb3VyY2VzIHByb3ZpZGVk\nCmJ5IEdpdEh1YiB0aHJvdWdoIGl0cyBBUEksIGFuZCBfYWN0aW9uc18gdGhh\ndCBjYW4gaW50ZXJhY3Qgd2l0aCB0aGUgcGxhdGZvcm0gaW4KdmFyaW91cyB3\nYXlzLgoKIyMgU3RhdHVzCgpXZSBhcmUgYWN0aXZlbHkgZGV2ZWxvcGluZyBg\nZ2l0aHViLXBhcnRzYC4gSXRzIEFQSSBhbmQgZnVuY3Rpb25hbGl0eSBhcmUg\nbm90CnN0YWJsZSBhbmQgY2FuIGNoYW5nZSBhdCBhbnkgdGltZS4gRHVyaW5n\nIHRoaXMgcGVyaW9kLCB3ZSBkb24ndCBhY2NlcHQgY29kZQpjb250cmlidXRp\nb25zIHRvIHRoZSBwcm9qZWN0LgoKIyMgTGljZW5zZQoKTGljZW5zZWQgdW5k\nZXIgZWl0aGVyIG9mCgotIEFwYWNoZSBMaWNlbnNlLCBWZXJzaW9uIDIuMCAo\nW0xJQ0VOU0UtQVBBQ0hFXShMSUNFTlNFLUFQQUNIRSkgb3IgPGh0dHA6Ly93\nd3cuYXBhY2hlLm9yZy9saWNlbnNlcy9MSUNFTlNFLTIuMD4pCi0gTUlUIGxp\nY2Vuc2UgKFtMSUNFTlNFLU1JVF0oTElDRU5TRS1NSVQpIG9yIDxodHRwOi8v\nb3BlbnNvdXJjZS5vcmcvbGljZW5zZXMvTUlUPikKCmF0IHlvdXIgb3B0aW9u\nLgoKIyMgQ29udHJpYnV0aW9uCgpVbmxlc3MgeW91IGV4cGxpY2l0bHkgc3Rh\ndGUgb3RoZXJ3aXNlLCBhbnkgY29udHJpYnV0aW9uIGludGVudGlvbmFsbHkg\nc3VibWl0dGVkCmZvciBpbmNsdXNpb24gaW4gdGhlIHdvcmsgYnkgeW91LCBh\ncyBkZWZpbmVkIGluIHRoZSBBcGFjaGUtMi4wIGxpY2Vuc2UsIHNoYWxsIGJl\nCmR1YWwgbGljZW5zZWQgYXMgYWJvdmUsIHdpdGhvdXQgYW55IGFkZGl0aW9u\nYWwgdGVybXMgb3IgY29uZGl0aW9ucy4KCltkZXYgeCBib3RzXTogaHR0cHM6\nLy9naXRodWIuY29tL2Rldnhib3RzCg==\n".to_string(),
+            sha: "3928ebd3c7db689f5ea5b11db6bfa89b132139c3".to_string()
+        });
+
+        let result =
+            GetFileResult::try_from(payload).expect("failed to convert payload into a result");
+
+        let content =
+            String::from_utf8(result.content).expect("failed to convert content to string");
+
+        assert!(content.starts_with("# 🔩 github-parts"))
+    }
+}

--- a/src/action/get_file/result.rs
+++ b/src/action/get_file/result.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+/// Get file result
+///
+/// The `get_file` action returns a file object with some metadata and the file's contents as a
+/// binary blob.
+#[derive(
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Default,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+)]
+pub struct GetFileResult {
+    /// Returns the size of the file.
+    #[getset(get_copy = "pub")]
+    pub(super) size: u64,
+
+    /// Returns the name of the file.
+    #[getset(get = "pub")]
+    pub(super) name: String,
+
+    /// Returns the path of the file inside the repository.
+    #[getset(get = "pub")]
+    pub(super) path: PathBuf,
+
+    /// Returns the file content.
+    #[getset(get = "pub")]
+    pub(super) content: Vec<u8>,
+
+    /// Returns the SHA hash of the file.
+    #[getset(get = "pub")]
+    pub(super) sha: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GetFileResult;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<GetFileResult>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<GetFileResult>();
+    }
+}

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,0 +1,7 @@
+//! Actions
+//!
+//! `github-parts` provides high-level actions that interact with the GitHub platform. The actions
+//! use one or more APIs to achieve their goal, hiding the complexity that is normally associated
+//! with their particular workflow.
+
+pub mod get_file;

--- a/src/github/token.rs
+++ b/src/github/token.rs
@@ -95,7 +95,7 @@ impl InstallationToken {
     pub async fn new(
         endpoint: &GitHubHost,
         app_token: &AppToken,
-        installation: InstallationId,
+        installation: &InstallationId,
     ) -> Result<InstallationToken, Error> {
         let url = format!(
             "{}/app/installations/{}/access_tokens",
@@ -167,7 +167,7 @@ mod tests {
         let installation_id = InstallationId::new(1);
 
         let installation_token =
-            InstallationToken::new(&github_host, &app_token, installation_id).await;
+            InstallationToken::new(&github_host, &app_token, &installation_id).await;
 
         assert!(installation_token.is_ok());
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ macro_rules! id {
 }
 
 pub mod account;
+pub mod action;
 pub mod check_run;
 pub mod error;
 pub mod event;


### PR DESCRIPTION
A new action has been prototyped that can get a file from a repository on GitHub. When the action is succesfull, it returns a file object with the decoded file content. Otherwise, an error is returned.

The action is very much a prototype, and its interface and return types will very likely change as we start using it.