### PR TITLE
Handle NOT FOUND error when getting a file

### DIFF
--- a/src/action/get_file/error.rs
+++ b/src/action/get_file/error.rs
@@ -26,6 +26,10 @@ pub enum GetFileError {
     #[error("encoding {0} is not supported")]
     Encoding(String),
 
+    /// The file was not found
+    #[error("file not found")]
+    NotFound,
+
     /// The outgoing request to GitHub failed
     #[error("querying the content failed. {0}")]
     Request(#[from] reqwest::Error),

--- a/src/action/get_file/payload.rs
+++ b/src/action/get_file/payload.rs
@@ -1,7 +1,15 @@
 use base64::decode;
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::action::get_file::{GetFileError, GetFileResult};
+
+#[derive(Clone, Eq, PartialEq, Debug, Deserialize)]
+#[serde(untagged)]
+pub enum GetFileResponse {
+    Error(GetFileErrorPayload),
+    Success(Value),
+}
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -26,6 +34,11 @@ pub struct FilePayload {
 #[serde(rename_all = "snake_case")]
 pub enum FileEncoding {
     Base64,
+}
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
+pub struct GetFileErrorPayload {
+    message: String,
 }
 
 impl TryFrom<GetFilePayload> for GetFileResult {
@@ -54,8 +67,9 @@ impl TryFrom<GetFilePayload> for GetFileResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{FileEncoding, FilePayload, GetFilePayload};
     use crate::action::get_file::GetFileResult;
+
+    use super::{FileEncoding, FilePayload, GetFilePayload};
 
     const PAYLOAD: &str = r#"
         {


### PR DESCRIPTION
When a user tries to get a file from GitHub that doesn't exist, GitHub responds with a HTTP 404 NOT FOUND response. The response was previously not caught, and caused the workflow to fail completely. This has been fixed, and an error response from GitHub is now converted to a meaningful error inside the crate.