### PR TITLE
Refactor error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ publish = false
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.57"
 base64 = "0.13.0"
 chrono = "0.4.19"
 getset = "0.1.2"

--- a/src/action/get_file/error.rs
+++ b/src/action/get_file/error.rs
@@ -1,42 +1,15 @@
-use base64::DecodeError;
 use thiserror::Error;
-
-use crate::error::Error;
 
 /// Errors that can occur when getting a file from GitHub
 #[derive(Debug, Error)]
 pub enum GetFileError {
-    /// An invalid argument was passed to the action
-    #[error("argument was invalid. {0}")]
-    Argument(String),
-
-    /// Authenticating with GitHub failed
-    #[error("authentication failed. {0}")]
-    Authentication(#[from] Error),
-
-    /// Decoding the file's content failed
-    #[error("decoding content failed. {0}")]
-    Decoding(#[from] DecodeError),
-
-    /// The user tried to get a directory
-    #[error("path was a directory, but must be a file")]
-    Directory,
-
-    /// The file encoding is not supported by the crate
-    #[error("encoding {0} is not supported")]
-    Encoding(String),
-
     /// The file was not found
     #[error("file not found")]
     NotFound,
 
-    /// The outgoing request to GitHub failed
-    #[error("querying the content failed. {0}")]
-    Request(#[from] reqwest::Error),
-
-    /// Deserializing the payload in the API response failed
-    #[error("response could not be deserialized. {0}")]
-    Response(#[from] serde_json::Error),
+    /// The user tried to get a directory
+    #[error("path was a directory, but must be a file")]
+    Directory,
 
     /// The user tried to get a git submodule
     #[error("path was a submodule, but must be a file")]
@@ -46,6 +19,10 @@ pub enum GetFileError {
     // TODO: Follow symlinks and return the file
     #[error("path was a symlink, but must be a file")]
     Symlink,
+
+    /// An unexpected error occurred while running the action
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
 }
 
 #[cfg(test)]

--- a/src/action/get_file/payload.rs
+++ b/src/action/get_file/payload.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use base64::decode;
 use serde::Deserialize;
 use serde_json::Value;
@@ -53,7 +54,8 @@ impl TryFrom<GetFilePayload> for GetFileResult {
         }?;
 
         let sanitized_content = &payload.content.replace('\n', "");
-        let content = decode(sanitized_content)?;
+        let content =
+            decode(sanitized_content).context("failed to decode Base64 encoded file content")?;
 
         Ok(GetFileResult {
             size: payload.size,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,24 @@
 //! Internal errors
 
-use thiserror::Error as ThisError;
-
 /// Errors that can occur inside github-parts
 ///
 /// github-parts interacts with external resources, for example GitHub's API, which always has a
 /// chance of failing due to a variety of reasons. The different errors that can occur are
 /// represented by this struct. Consumers of the crate can decide if they want to rethrow an error
 /// or retry an operation.
-#[derive(Debug, ThisError)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Authenticating with GitHub failed
-    #[error("authentication failed with the following error: {0}")]
-    Authentication(#[from] jsonwebtoken::errors::Error),
-
-    /// An operation inside the crate failed
-    #[error("{0}")]
-    Internal(String),
+    /// The configuration of the crate is invalid or caused an error
+    #[error("{1}")]
+    Configuration(#[source] Box<dyn std::error::Error + Send + Sync>, String),
 
     /// Accessing external resources failed
-    #[error("an outgoing request failed with the following error: {0}")]
-    Request(#[from] reqwest::Error),
+    #[error(transparent)]
+    ExternalResource(#[from] reqwest::Error),
+
+    /// An operation inside the crate failed
+    #[error(transparent)]
+    UnexpectedError(#[from] anyhow::Error),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The error types in the crate have been refactored to increase their usability. Overly verbose variants of both error types have been removed, and the anyhow crate has been added to capture context around unexpected errors.

This is just the first step on a long journey to provide a clean API for errors that can occur within the crate. As we gain more experience with actions and the workflows built on top of them, we will most likely refactor the errors at least once.