### PR TITLE
Create entity for check suites

### DIFF
--- a/src/check_suite/mod.rs
+++ b/src/check_suite/mod.rs
@@ -1,0 +1,57 @@
+//! Check suite
+//!
+//! When code is pushed to GitHub, a new check suite is started. Apps and integrations can then
+//! start check runs inside this suite, and GitHub will show them together in the UI.
+
+use std::fmt::{Display, Formatter};
+
+use getset::CopyGetters;
+use serde::{Deserialize, Serialize};
+
+use crate::check_run::{CheckRunConclusion, CheckRunStatus};
+
+id!(CheckSuiteId);
+
+/// Check suite
+///
+/// When code is pushed to GitHub, a new check suite is started. Apps and integrations can then
+/// start check runs inside this suite, and GitHub will show them together in the UI.
+///
+/// The `status` and `conclusion` of a check suite are derived from its check runs.
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
+)]
+pub struct CheckSuite {
+    /// Returns the check suite id.
+    #[getset(get_copy = "pub")]
+    id: CheckSuiteId,
+
+    /// Returns the status of the check suite.
+    #[getset(get_copy = "pub")]
+    status: CheckRunStatus,
+
+    /// Returns the conclusion of the check suite.
+    #[getset(get_copy = "pub")]
+    conclusion: CheckRunConclusion,
+
+    /// Returns the latest number of check runs that are part of the suite.
+    #[getset(get_copy = "pub")]
+    latest_check_runs_count: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckSuite;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckSuite>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckSuite>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ macro_rules! id {
 pub mod account;
 pub mod action;
 pub mod check_run;
+pub mod check_suite;
 pub mod error;
 pub mod event;
 pub mod github;


### PR DESCRIPTION
When code is pushed to GitHub, a new check suite is created. Apps and
integrations can add their check runs to this suite so that they show up
together in the UI.