### PR TITLE
Add check suite to check run entity

### DIFF
--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter};
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
+use crate::check_suite::CheckSuite;
 use crate::{id, name};
 
 pub use self::check_run_conclusion::CheckRunConclusion;
@@ -37,6 +38,10 @@ pub struct CheckRun {
     /// Returns the name of the check run.
     #[getset(get = "pub")]
     name: CheckRunName,
+
+    /// Returns the check suite that the check run is a part of.
+    #[getset(get = "pub")]
+    check_suite: CheckSuite,
 
     /// Returns the status of the check run.
     #[getset(get_copy = "pub")]

--- a/src/check_suite/mod.rs
+++ b/src/check_suite/mod.rs
@@ -32,12 +32,14 @@ pub struct CheckSuite {
     status: CheckRunStatus,
 
     /// Returns the conclusion of the check suite.
+    ///
+    /// The conclusion is only set when the status of at least one check run is `completed`.
     #[getset(get_copy = "pub")]
-    conclusion: CheckRunConclusion,
+    conclusion: Option<CheckRunConclusion>,
 
     /// Returns the latest number of check runs that are part of the suite.
     #[getset(get_copy = "pub")]
-    latest_check_runs_count: u64,
+    latest_check_runs_count: Option<u64>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Check runs reference the suite that they belong to, both when querying a check run through the API and when receiving a check run event.