### PR TITLE
Remove documentation

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,9 +1,3 @@
-//! GitHub account
-//!
-//! Repositories hosted on GitHub belong to an account, which can be either an organization or a
-//! user. Accounts have various unique properties such as a `login` and an `id` that are used to
-//! identify and interact with them.
-
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
@@ -19,18 +13,10 @@ mod user;
 id!(AccountId);
 name!(Login);
 
-/// GitHub account
-///
-/// An account on GitHub can represent either an organization or a user. Accounts have a unique `id`
-/// that is used throughout GitHub's REST API to identify accounts. They also have a `login`, which
-/// is a human-readable name that must be unique, but can be changed by the owner.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 pub enum Account {
-    /// An organization
     Organization(Organization),
-
-    /// A user
     User(User),
 }
 

--- a/src/account/organization.rs
+++ b/src/account/organization.rs
@@ -1,8 +1,3 @@
-//! GitHub organization
-//!
-//! Organizations have various unique properties such as a `login` and an `id` that are used to
-//! identify and interact with them.
-
 use std::fmt::{Display, Formatter};
 
 use getset::{CopyGetters, Getters};
@@ -10,26 +5,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::account::{AccountId, Login};
 
-/// GitHub organization
-///
-/// Organizations on GitHub have a unique `id` that is used throughout GitHub's REST API to identify
-/// them. They also have a `login`, which is a human-readable name that must be unique, but can be
-/// changed by the owner.
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
 )]
 pub struct Organization {
-    /// Returns the login of the organization.
     #[getset(get = "pub")]
     login: Login,
 
-    /// Returns the id of the organization.
     #[getset(get_copy = "pub")]
     id: AccountId,
 }
 
 impl Organization {
-    /// Initializes a new organization.
     pub fn new(login: Login, id: AccountId) -> Self {
         Self { login, id }
     }

--- a/src/account/user.rs
+++ b/src/account/user.rs
@@ -1,8 +1,3 @@
-//! GitHub user
-//!
-//! Users have various unique properties such as a `login` and an `id` that are used to identify and
-//! interact with them.
-
 use std::fmt::{Display, Formatter};
 
 use getset::{CopyGetters, Getters};
@@ -10,26 +5,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::account::{AccountId, Login};
 
-/// GitHub user
-///
-/// Users on GitHub have a unique `id` that is used throughout GitHub's REST API to identify users.
-/// They also have a `login`, which is a human-readable name that must be unique, but can be changed
-/// by the owner.
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
 )]
 pub struct User {
-    /// Returns the login of the user.
     #[getset(get = "pub")]
     login: Login,
 
-    /// Returns the id of the user.
     #[getset(get_copy = "pub")]
     id: AccountId,
 }
 
 impl User {
-    /// Initializes a new user.
     pub fn new(login: Login, id: AccountId) -> Self {
         Self { login, id }
     }

--- a/src/action/get_file/error.rs
+++ b/src/action/get_file/error.rs
@@ -1,26 +1,20 @@
 use thiserror::Error;
 
-/// Errors that can occur when getting a file from GitHub
 #[derive(Debug, Error)]
 pub enum GetFileError {
-    /// The file was not found
     #[error("file not found")]
     NotFound,
 
-    /// The user tried to get a directory
     #[error("path was a directory, but must be a file")]
     Directory,
 
-    /// The user tried to get a git submodule
     #[error("path was a submodule, but must be a file")]
     Submodule,
 
-    /// The user tried to get a symlink
     // TODO: Follow symlinks and return the file
     #[error("path was a symlink, but must be a file")]
     Symlink,
 
-    /// An unexpected error occurred while running the action
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
 }

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -1,5 +1,3 @@
-//! Get a file from a repository on GitHub
-
 use anyhow::Context;
 use reqwest::Client;
 
@@ -18,9 +16,6 @@ mod error;
 mod payload;
 mod result;
 
-/// Get a file
-///
-/// This action downloads a file from GitHub.
 pub async fn get_file(
     github_host: &GitHubHost,
     app_id: &AppId,

--- a/src/action/get_file/result.rs
+++ b/src/action/get_file/result.rs
@@ -3,10 +3,6 @@ use std::path::PathBuf;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
-/// Get file result
-///
-/// The `get_file` action returns a file object with some metadata and the file's contents as a
-/// binary blob.
 #[derive(
     Clone,
     Eq,
@@ -22,23 +18,18 @@ use serde::{Deserialize, Serialize};
     Getters,
 )]
 pub struct GetFileResult {
-    /// Returns the size of the file.
     #[getset(get_copy = "pub")]
     pub(super) size: u64,
 
-    /// Returns the name of the file.
     #[getset(get = "pub")]
     pub(super) name: String,
 
-    /// Returns the path of the file inside the repository.
     #[getset(get = "pub")]
     pub(super) path: PathBuf,
 
-    /// Returns the file content.
     #[getset(get = "pub")]
     pub(super) content: Vec<u8>,
 
-    /// Returns the SHA hash of the file.
     #[getset(get = "pub")]
     pub(super) sha: String,
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,7 +1,1 @@
-//! Actions
-//!
-//! `github-parts` provides high-level actions that interact with the GitHub platform. The actions
-//! use one or more APIs to achieve their goal, hiding the complexity that is normally associated
-//! with their particular workflow.
-
 pub mod get_file;

--- a/src/check_run/check_run_conclusion.rs
+++ b/src/check_run/check_run_conclusion.rs
@@ -2,31 +2,15 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// Check run conclusion
-///
-/// When a check run finishes, its result is indicated by the `conclusion`.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckRunConclusion {
-    /// The check run finished successfully.
     Success,
-
-    /// The check run failed.
     Failure,
-
-    /// The check run finished without a conclusion.
     Neutral,
-
-    /// The check run was cancelled.
     Cancelled,
-
-    /// The check run timed out.
     TimedOut,
-
-    /// The check run requires an action by the user.
     ActionRequired,
-
-    /// The check run is stale.
     Stale,
 }
 

--- a/src/check_run/check_run_status.rs
+++ b/src/check_run/check_run_status.rs
@@ -2,20 +2,11 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// Check run status
-///
-/// Check runs have a status, which indicates whether the check run has already started, is
-/// currently running, or has finished.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckRunStatus {
-    /// The check run has been queued, but not started yet.
     Queued,
-
-    /// The check run is currently running.
     InProgress,
-
-    /// The check run has finished.
     Completed,
 }
 

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -1,8 +1,3 @@
-//! Check run
-//!
-//! When code is pushed to GitHub, apps and integrations can start check runs to perform arbitrary
-//! tasks, e.g. run tests or perform static analysis.
-
 use std::fmt::{Display, Formatter};
 
 use getset::{CopyGetters, Getters};
@@ -20,36 +15,22 @@ mod check_run_status;
 id!(CheckRunId);
 name!(CheckRunName);
 
-/// Check run
-///
-/// When code is pushed to GitHub, apps and integrations can start check runs to perform arbitrary
-/// tasks, e.g. run tests or perform static analysis. These check runs end with a conclusion that
-/// informs the user about the success or failure of the task.
-///
-/// The `conclusion` of a check run is only available when the check run has been completed.
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
 )]
 pub struct CheckRun {
-    /// Returns the unique id of the check run.
     #[getset(get_copy = "pub")]
     id: CheckRunId,
 
-    /// Returns the name of the check run.
     #[getset(get = "pub")]
     name: CheckRunName,
 
-    /// Returns the check suite that the check run is a part of.
     #[getset(get = "pub")]
     check_suite: CheckSuite,
 
-    /// Returns the status of the check run.
     #[getset(get_copy = "pub")]
     status: CheckRunStatus,
 
-    /// Returns the conclusion of the check run.
-    ///
-    /// The conclusion is only set when the status of the check run is `completed`.
     #[getset(get_copy = "pub")]
     conclusion: Option<CheckRunConclusion>,
 }

--- a/src/check_suite/mod.rs
+++ b/src/check_suite/mod.rs
@@ -1,8 +1,3 @@
-//! Check suite
-//!
-//! When code is pushed to GitHub, a new check suite is started. Apps and integrations can then
-//! start check runs inside this suite, and GitHub will show them together in the UI.
-
 use std::fmt::{Display, Formatter};
 
 use getset::CopyGetters;
@@ -13,31 +8,19 @@ use crate::id;
 
 id!(CheckSuiteId);
 
-/// Check suite
-///
-/// When code is pushed to GitHub, a new check suite is started. Apps and integrations can then
-/// start check runs inside this suite, and GitHub will show them together in the UI.
-///
-/// The `status` and `conclusion` of a check suite are derived from its check runs.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
 )]
 pub struct CheckSuite {
-    /// Returns the check suite id.
     #[getset(get_copy = "pub")]
     id: CheckSuiteId,
 
-    /// Returns the status of the check suite.
     #[getset(get_copy = "pub")]
     status: CheckRunStatus,
 
-    /// Returns the conclusion of the check suite.
-    ///
-    /// The conclusion is only set when the status of at least one check run is `completed`.
     #[getset(get_copy = "pub")]
     conclusion: Option<CheckRunConclusion>,
 
-    /// Returns the latest number of check runs that are part of the suite.
     #[getset(get_copy = "pub")]
     latest_check_runs_count: Option<u64>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,11 @@
-//! Internal errors
-
-/// Errors that can occur inside github-parts
-///
-/// github-parts interacts with external resources, for example GitHub's API, which always has a
-/// chance of failing due to a variety of reasons. The different errors that can occur are
-/// represented by this struct. Consumers of the crate can decide if they want to rethrow an error
-/// or retry an operation.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// The configuration of the crate is invalid or caused an error
     #[error("{1}")]
     Configuration(#[source] Box<dyn std::error::Error + Send + Sync>, String),
 
-    /// Accessing external resources failed
     #[error(transparent)]
     ExternalResource(#[from] reqwest::Error),
 
-    /// An operation inside the crate failed
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
 }

--- a/src/event/check_run/action.rs
+++ b/src/event/check_run/action.rs
@@ -2,30 +2,12 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// The action performed
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Action {
-    /// A new check run was created.
     Created,
-
-    /// The `status` of the check run is `completed`.
     Completed,
-
-    /// Someone requested to re-run your check run from the pull request UI.
-    ///
-    /// See [About status checks](https://docs.github.com/en/articles/about-status-checks#checks)
-    /// for more details about the GitHub UI. When you receive a `rerequested` action, you'll need
-    /// to [create a new check run](https://docs.github.com/en/rest/reference/checks#create-a-check-run).
-    /// Only the GitHub App that someone requests to re-run the check will receive the `rerequested`
-    /// payload.
     Rerequested,
-
-    /// Someone requested an action your app provides to be taken.
-    ///
-    /// Only the GitHub App someone requests to perform an action will receive the
-    /// `requested_action` payload. To learn more about check runs and requested actions, see
-    /// [Check runs and requested actions](https://docs.github.com/en/rest/reference/checks#check-runs-and-requested-actions).
     RequestedAction,
 }
 

--- a/src/event/check_run/mod.rs
+++ b/src/event/check_run/mod.rs
@@ -1,8 +1,3 @@
-//! Check run event
-//!
-//! Check run activity has occurred. The type of activity is specified in the `action` property of
-//! the payload object.
-
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
@@ -15,61 +10,28 @@ pub use self::action::Action;
 
 mod action;
 
-/// Check run event
-///
-/// Check run activity has occurred. The type of activity is specified in the `action` property of
-/// the payload object. For more information, see the [check runs](https://docs.github.com/en/rest/reference/checks#runs)
-/// REST API.
-///
-/// # Note
-///
-/// The Checks API only looks for pushes in the repository where the check suite or check run were
-/// created. Pushes to a branch in a forked repository are not detected and return an empty
-/// `pull_requests` array and a `null` value for `head_branch`.
-///
-/// # Availability
-///
-/// - Repository webhooks only receive payloads for the `created` and `completed` event types in a
-///   repository
-/// - Organization webhooks only receive payloads for the `created` and `completed` event types in
-///   repositories
-/// - GitHub Apps with the `checks:read` permission receive payloads for the `created` and
-///   `completed` events that occur in the repository where the app is installed. The app must have
-///   the `checks:write` permission to receive the `rerequested` and `requested_action` event types.
-///   The `rerequested` and `requested_action` event type payloads are only sent to the GitHub App
-///   being requested. GitHub Apps with the `checks:write` are automatically subscribed to this
-///   webhook event.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters)]
 pub struct CheckRunEvent {
-    /// The [`Action`] performed.
     #[getset(get = "pub")]
     action: Action,
 
-    /// The [`CheckRun`].
     #[getset(get = "pub")]
     check_run: CheckRun,
 
-    /// The [`Repository`] where the event occurred.
     #[getset(get = "pub")]
     repository: Repository,
 
-    /// Webhook payloads contain the `organization` object when the webhook is configured for an
-    /// organization or the event occurs from activity in a repository owned by an organization.
     #[getset(get = "pub")]
     organization: Option<Organization>,
 
-    /// The GitHub App installation. Webhook payloads contain the `installation` property when the
-    /// event is configured for and sent to a GitHub App.
     #[getset(get = "pub")]
     installation: Option<Installation>,
 
-    /// The user that triggered the event.
     #[getset(get = "pub")]
     sender: Account,
 }
 
 impl CheckRunEvent {
-    /// Initializes a new check run event.
     pub fn new(
         action: Action,
         check_run: CheckRun,

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,11 +1,3 @@
-//! Webhook events
-//!
-//! GitHub enables integrations to subscribe to events. Whenever such an event happens on GitHub, a
-//! webhook is sent to the integration. Events correspond to certain actions, for example the
-//! `issue` event is fired everytime an issue is opened, closed, labeled, etc.
-//!
-//! Read more: <https://docs.github.com/en/developers/webhooks-and-events/webhooks>
-
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
@@ -14,28 +6,9 @@ pub use self::check_run::CheckRunEvent;
 
 mod check_run;
 
-/// Webhook event
-///
-/// GitHub provides a wide variety of events, which enable integrations to react to almost any
-/// action that is taken on the platform. Webhooks represent a single event, and their payload is
-/// deserialized to the [`Event`] enum.
-///
-/// Events that are not yet supported by [`github-parts`] are captured in the `Event::Unsupported`
-/// variant. It contains [`serde_json::Value`] payload, which makes it possible to still work with
-/// the event.
-///
-/// Read more: <https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads>
 #[derive(Clone, Eq, PartialEq, Debug, Deserialize, Serialize)]
 pub enum Event {
-    /// Check run activity has occurred.
-    ///
-    /// The type of activity is specified in the `action` property of the payload object.
     CheckRun(Box<CheckRunEvent>),
-
-    /// Unsupported event
-    ///
-    /// This event is not yet supported by [`github-parts`], but the webhook payload is passed
-    /// through as a [`serde_json::Value`] so that consumers can still work with it.
     Unsupported(serde_json::Value),
 }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,5 +1,3 @@
-//! Entities to interact with GitHub
-
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};

--- a/src/github/private_key.rs
+++ b/src/github/private_key.rs
@@ -1,19 +1,13 @@
 use secrecy::{ExposeSecret, SecretString};
 
-/// GitHub App private key
-///
-/// GitHub Apps have a private key that is combined with the app's `id` to authenticate the app
-/// against GitHub's API.
 #[derive(Clone, Debug)]
 pub struct PrivateKey(SecretString);
 
 impl PrivateKey {
-    /// Initializes a new private key.
     pub fn new(private_key: String) -> Self {
         Self(SecretString::new(private_key))
     }
 
-    /// Returns the private key.
     pub fn get(&self) -> &str {
         self.0.expose_secret()
     }

--- a/src/github/token.rs
+++ b/src/github/token.rs
@@ -1,9 +1,3 @@
-//! Authentication tokens for GitHub
-//!
-//! github-parts interacts with GitHub through its REST API. It authenticates as a GitHub App by
-//! default, but can also authenticate as an installation. Both scopes have their own `Token`, and
-//! actions can declare which one they need through Rust's type system.
-
 use anyhow::Context;
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
@@ -15,24 +9,9 @@ use crate::error::Error;
 use crate::github::{AppId, GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 
-/// Authentication token for GitHub App
-///
-/// github-parts interacts with GitHub through its REST API and uses authentication tokens to
-/// identify itself. The `AppToken` represents the GitHub App itself, and can be used to interact
-/// with GitHub's API on behalf of the app.
-///
-/// https://docs.github.com/en/developers/apps/authenticating-with-github-apps
 #[derive(Clone, Debug)]
 pub struct AppToken(SecretString);
 
-/// Authentication token for installations
-///
-/// github-parts interacts with GitHub through its REST API and uses authentication tokens to
-/// identify itself. The `InstallationToken` represents the installation of the GitHub App in a
-/// specific account, and can be used to interact with the resources of this particular
-/// installation.
-///
-/// https://docs.github.com/en/developers/apps/authenticating-with-github-apps
 #[derive(Clone, Debug)]
 pub struct InstallationToken(SecretString);
 
@@ -49,12 +28,6 @@ struct AccessTokensResponse {
 }
 
 impl AppToken {
-    /// Create a new app token
-    ///
-    /// The app token can be used to request resources on behalf of the GitHub App. It is created by
-    /// initializing a JSON Web Token and signing it with the app's private key.
-    ///
-    /// https://jwt.io/
     pub fn new(app_id: &AppId, private_key: &PrivateKey) -> Result<Self, Error> {
         let now = Utc::now();
 
@@ -86,19 +59,12 @@ impl AppToken {
         Ok(Self(SecretString::new(jwt)))
     }
 
-    /// Get the token
     pub fn get(&self) -> &str {
         self.0.expose_secret()
     }
 }
 
 impl InstallationToken {
-    /// Request a new installation token
-    ///
-    /// The installation token can be used to request resources on behalf of the installation. The
-    /// token is created by requesting it from GitHub using the app token.
-    ///
-    /// https://docs.github.com/en/developers/apps/authenticating-with-github-apps
     pub async fn new(
         endpoint: &GitHubHost,
         app_token: &AppToken,
@@ -123,7 +89,6 @@ impl InstallationToken {
         Ok(Self(SecretString::new(access_token_response.token)))
     }
 
-    /// Get the token
     pub fn get(&self) -> &str {
         self.0.expose_secret()
     }

--- a/src/github/webhook_secret.rs
+++ b/src/github/webhook_secret.rs
@@ -1,19 +1,13 @@
 use secrecy::{ExposeSecret, SecretString};
 
-/// Webhook secret
-///
-/// GitHub adds a cryptographic signature based on a shared secret to its webhooks. The signature
-/// can be used to verify that the webhook was sent by GitHub and not a malicious party.
 #[derive(Clone, Debug)]
 pub struct WebhookSecret(SecretString);
 
 impl WebhookSecret {
-    /// Initializes a new webhook secret.
     pub fn new(webhook_secret: String) -> Self {
         Self(SecretString::new(webhook_secret))
     }
 
-    /// Returns the webhook secret.
     pub fn get(&self) -> &str {
         self.0.expose_secret()
     }

--- a/src/installation/mod.rs
+++ b/src/installation/mod.rs
@@ -1,7 +1,3 @@
-//! Installation
-//!
-//! When a GitHub App is added to a repository, it's called an installation.
-
 use std::fmt::{Display, Formatter};
 
 use getset::CopyGetters;
@@ -11,22 +7,15 @@ use crate::id;
 
 id!(InstallationId);
 
-/// Installation
-///
-/// When a GitHub App is added to a repository, it's called an installation. Each installation has a
-/// unique `id` that can be used by the GitHub App to authenticate and interact with a specific
-/// repository.
 #[derive(
     Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
 )]
 pub struct Installation {
-    /// Returns the installation id.
     #[getset(get_copy = "pub")]
     id: InstallationId,
 }
 
 impl Installation {
-    /// Initializes a new installation.
     pub fn new(id: InstallationId) -> Self {
         Self { id }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,3 @@
-//! Types and actions for GitHub
-//!
-//! [`github-parts`] is a tailor-made integration with GitHub. It is designed to make it easier to
-//! build GitHub Apps, and thus focuses mostly on [webhook events and payloads]. The crate contains
-//! _types_ that represent resources on GitHub, and _actions_ that can create and modify them.
-//!
-//! [webhook events and payloads]: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads
-
-#![warn(missing_docs)]
-
 mod macros;
 
 pub mod account;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,23 +1,16 @@
-/// Generate a new id type
 #[macro_export]
 macro_rules! id {
     ($id:ident) => {
-        /// Identifier
-        ///
-        /// Resources on GitHub have a unique `id` that is used to interact with them through
-        /// GitHub's REST API.
         #[derive(
             Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize,
         )]
         pub struct $id(u64);
 
         impl $id {
-            /// Initializes a new identifier.
             pub fn new(id: u64) -> Self {
                 Self(id)
             }
 
-            /// Returns the identifier.
             pub fn get(&self) -> u64 {
                 self.0
             }
@@ -31,23 +24,17 @@ macro_rules! id {
     };
 }
 
-/// Generate a new name type
 #[macro_export]
 macro_rules! name {
     ($name:ident) => {
-        /// Name
-        ///
-        /// Resources on GitHub can have a human-readable name that identifies them.
         #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
         pub struct $name(String);
 
         impl $name {
-            /// Initializes a new name.
             pub fn new(name: impl Into<String>) -> Self {
                 Self(name.into())
             }
 
-            /// Returns a string representation of the name.
             pub fn get(&self) -> &str {
                 &self.0
             }

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,8 +1,3 @@
-//! Repository
-//!
-//! Repositories store source code using the Git version control system. They are the core resource
-//! on GitHub, and almost everything else is organized around them.
-
 use std::fmt::{Display, Formatter};
 
 use getset::{CopyGetters, Getters};
@@ -15,38 +10,27 @@ use crate::{id, name};
 id!(RepositoryId);
 name!(RepositoryName);
 
-/// Repository
-///
-/// Repositories are uniquely identified by the combination of their `owner` and `name`. They have
-/// a `id` that never changes, even if the repository is renamed, and a `visibility` that indicates
-/// whether the repository is public or private.
 #[derive(
     Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
 )]
 pub struct Repository {
-    /// Returns the id of the repository.
     #[getset(get_copy = "pub")]
     id: RepositoryId,
 
-    /// Returns the name of the repository.
     #[getset(get = "pub")]
     name: RepositoryName,
 
-    /// Returns the description of the repository.
     #[getset(get = "pub")]
     description: Option<String>,
 
-    /// Returns the owner of the repository.
     #[getset(get = "pub")]
     owner: Account,
 
-    /// Returns the visibility of the repository.
     #[getset(get_copy = "pub")]
     visibility: Visibility,
 }
 
 impl Repository {
-    /// Initializes a new repository.
     pub fn new(
         id: RepositoryId,
         name: RepositoryName,
@@ -63,11 +47,6 @@ impl Repository {
         }
     }
 
-    /// Returns the full name of the repository.
-    ///
-    /// The full name of a repository is the combination of the owner's login and the repository's
-    /// name. This combination can be used to uniquely identify a repository on GitHub, and is thus
-    /// often used to reference them externally.
     pub fn full_name(&self) -> String {
         let login = match &self.owner {
             Account::Organization(org) => org.login(),

--- a/src/visibility.rs
+++ b/src/visibility.rs
@@ -1,25 +1,11 @@
-//! Visibility
-//!
-//! Many resources on GitHub can either be public or private, which is called their visibility.
-//! Private resources are only accessible to the owner, team members, or collaborators. Public
-//! resources can be seen by anyone.
-
 use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-/// Visibility
-///
-/// Many resources on GitHub can either be public or private, which is called their visibility.
-/// Private resources are only accessible to the owner, team members, or collaborators. Public
-/// resources can be seen by anyone.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Visibility {
-    /// Only visible to the owner, team members, and collaborators
     Private,
-
-    /// Visible to everyone
     Public,
 }
 


### PR DESCRIPTION
When starting the crate, we enabled a lint that enforced documentation for public interfaces. This was premature, since we are still learning a lot and the API of the crate is changing as a consequence. As a result, most comments where not helpful and just placeholders.

The lint has been removed, as have all existing comments. When the crate has stabilized, we will reintroduce the lint and write proper documentation then.