### PR TITLE
Add pagination support to the GitHub client

### DIFF
--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -36,7 +36,7 @@ pub async fn get_file(
         path
     );
 
-    let response = client.request(Method::GET, &url).await;
+    let response = client.entity(Method::GET, &url).await;
 
     let payload = match response {
         Ok(payload) => payload,


### PR DESCRIPTION
The GitHub client now has a new method that can be used to fetch paginated resources. The client uses a naive implementation and fetches all resources, which might not be the best idea in certain situations.