### PR TITLE
Create entity for Git SHA

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,7 @@
+use std::fmt::{Display, Formatter};
+
+use serde::{Deserialize, Serialize};
+
+use crate::name;
+
+name!(HeadSha);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod check_run;
 pub mod check_suite;
 pub mod error;
 pub mod event;
+pub mod git;
 pub mod github;
 pub mod installation;
 pub mod repository;


### PR DESCRIPTION
Commits in Git are uniquely identified by their SHA hash. APIs that interact with the Git version control require the user to pass a SHA so that GitHub knows which commit to reference. A newtype has been created that represents this SHA.