### PR TITLE
Create trait for actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.57"
+async-trait = "0.1.56"
 base64 = "0.13.0"
 chrono = "0.4.19"
 getset = "0.1.2"

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -29,8 +29,7 @@ pub async fn get_file(
         GitHubClient::new(github_host, app_id, private_key, installation);
 
     let url = format!(
-        "{}/repos/{}/{}/contents/{}",
-        github_host.get(),
+        "/repos/{}/{}/contents/{}",
         owner.get(),
         repository.get(),
         path

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -1,2 +1,16 @@
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
 pub mod get_file;
 pub mod list_check_runs;
+
+#[async_trait]
+pub trait Action<Input, Output, Error>
+where
+    Input: Serialize,
+    Output: DeserializeOwned,
+    Error: std::error::Error,
+{
+    async fn execute(&self, input: &Input) -> Result<Output, Error>;
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -47,9 +47,11 @@ where
         }
     }
 
-    pub async fn entity(self, method: Method, url: &str) -> Result<T, GitHubClientError> {
+    pub async fn entity(&self, method: Method, endpoint: &str) -> Result<T, GitHubClientError> {
+        let url = format!("{}{}", self.github_host.get(), endpoint);
+
         let data = self
-            .client(method, url)
+            .client(method, &url)
             .await?
             .send()
             .await?
@@ -60,13 +62,15 @@ where
     }
 
     pub async fn paginate(
-        self,
+        &self,
         method: Method,
-        url: &str,
+        endpoint: &str,
         key: &str,
     ) -> Result<Vec<T>, GitHubClientError> {
+        let url = format!("{}{}", self.github_host.get(), endpoint);
+
         let mut collection = Vec::new();
-        let mut next_url = Some(String::from(url));
+        let mut next_url = Some(url);
 
         while next_url.is_some() {
             let response = self
@@ -196,8 +200,10 @@ mod tests {
             InstallationId::new(1),
         );
 
-        let url = format!("{}/repos/octocat/Hello-World", mockito::server_url());
-        let repository = client.entity(Method::GET, &url).await.unwrap();
+        let repository = client
+            .entity(Method::GET, "/repos/octocat/Hello-World")
+            .await
+            .unwrap();
 
         assert_eq!(1296269, repository.id().get());
     }
@@ -272,9 +278,8 @@ mod tests {
             InstallationId::new(1),
         );
 
-        let url = format!("{}/installation/repositories", mockito::server_url());
         let repository = client
-            .paginate(Method::GET, &url, "repositories")
+            .paginate(Method::GET, "/installation/repositories", "repositories")
             .await
             .unwrap();
 


### PR DESCRIPTION
Actions all follow the same pattern: They accept an input, interact with GitHub, and then return a result. As we are creating more actions, we want to capture as much shared logic as possible and make it reusable. For this purpose, a new trait has been created that describes an action.

The action to list check runs has been refactored already. The action to get a file however has a slightly different internal logic that is not (yet) compatible with the trait.