### PR TITLE
Add HEAD SHA to check run entity

### DIFF
--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -4,6 +4,7 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
 use crate::check_suite::CheckSuite;
+use crate::git::HeadSha;
 use crate::{id, name};
 
 pub use self::check_run_conclusion::CheckRunConclusion;
@@ -21,6 +22,9 @@ name!(CheckRunName);
 pub struct CheckRun {
     #[getset(get_copy = "pub")]
     id: CheckRunId,
+
+    #[getset(get = "pub")]
+    head_sha: HeadSha,
 
     #[getset(get = "pub")]
     name: CheckRunName,


### PR DESCRIPTION
The check run webhook from GitHub contains the SHA of the commit for which the check run was triggered. When an app wants to create a check run for the same commit, it must use the SHA to do so. It has therefore been added to the check run entity as a field.