### PR TITLE
Add getter for login to account entity

### DIFF
--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -20,6 +20,15 @@ pub enum Account {
     User(User),
 }
 
+impl Account {
+    pub fn login(&self) -> &Login {
+        match self {
+            Account::Organization(org) => org.login(),
+            Account::User(user) => user.login(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Account;

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -48,12 +48,7 @@ impl Repository {
     }
 
     pub fn full_name(&self) -> String {
-        let login = match &self.owner {
-            Account::Organization(org) => org.login(),
-            Account::User(user) => user.login(),
-        };
-
-        format!("{}/{}", login, self.name())
+        format!("{}/{}", self.owner.login(), self.name())
     }
 }
 


### PR DESCRIPTION
The account entity is an enumeration with an organization and a user variant. While the fields on both can slightly differ, they both have a `login` as their identifier. A new convenience method has been added to the account entity to return the login for both variants. Consumers don't need to match the variant anymore.