### PR TITLE
Add missing "skipped" conclusion for check runs

### DIFF
--- a/src/check_run/check_run_conclusion.rs
+++ b/src/check_run/check_run_conclusion.rs
@@ -8,6 +8,7 @@ pub enum CheckRunConclusion {
     Success,
     Failure,
     Neutral,
+    Skipped,
     Cancelled,
     TimedOut,
     ActionRequired,
@@ -20,6 +21,7 @@ impl Display for CheckRunConclusion {
             CheckRunConclusion::Success => "success",
             CheckRunConclusion::Failure => "failure",
             CheckRunConclusion::Neutral => "neutral",
+            CheckRunConclusion::Skipped => "skipped",
             CheckRunConclusion::Cancelled => "cancelled",
             CheckRunConclusion::TimedOut => "timed out",
             CheckRunConclusion::ActionRequired => "action required",
@@ -39,6 +41,7 @@ mod tests {
         assert_eq!("success", CheckRunConclusion::Success.to_string());
         assert_eq!("failure", CheckRunConclusion::Failure.to_string());
         assert_eq!("neutral", CheckRunConclusion::Neutral.to_string());
+        assert_eq!("skipped", CheckRunConclusion::Skipped.to_string());
         assert_eq!("cancelled", CheckRunConclusion::Cancelled.to_string());
         assert_eq!("timed out", CheckRunConclusion::TimedOut.to_string());
         assert_eq!(


### PR DESCRIPTION
The check run conclusion "skipped" was missing from the conclusion enumeration. This has been fixed, and all variants that GitHub supports are now represented by the enum.