### PR TITLE
Skip serializing empty options

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -57,8 +57,11 @@ impl<'a> Action<CreateCheckRunInput, CheckRun, CreateCheckRunError> for CreateCh
 pub struct CreateCheckRunInput {
     pub name: CheckRunName,
     pub head_sha: HeadSha,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<CheckRunStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conclusion: Option<CheckRunConclusion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
 }
 

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -58,8 +58,11 @@ impl<'a> Action<UpdateCheckRunInput, CheckRun, UpdateCheckRunError> for UpdateCh
 // TODO: Pass by reference, not by value (e.g. &HeadSha)
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
 pub struct UpdateCheckRunInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<CheckRunStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conclusion: Option<CheckRunConclusion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
 }
 


### PR DESCRIPTION
When crafting a request for GitHub, serializing an empty options causes the request to fail. GitHub will respond with a HTTP 422 error, since `null` is not a valid variant for the enumerations of the check run.