### PR TITLE
Refactor method for GET requests in GitHub client

### DIFF
--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -39,12 +39,8 @@ pub async fn get_file(
     let payload = match response {
         Ok(payload) => payload,
         Err(error) => {
-            if let GitHubClientError::Request(request_error) = &error {
-                if let Some(status) = request_error.status() {
-                    if status == 404 {
-                        return Err(GetFileError::NotFound);
-                    }
-                }
+            if let GitHubClientError::NotFound = &error {
+                return Err(GetFileError::NotFound);
             }
 
             return Err(anyhow!(error).into());


### PR DESCRIPTION
The method for GET requests inside the GitHub client has been refactored to use the same logic under the hood as the methods for POST and PATCH requests. This ensures that responses with an unexpected, i.e. faulty, return code are properly reported.