### PR TITLE
Cache token in GitHub client

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -10,9 +10,9 @@ use crate::git::HeadSha;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct CreateCheckRun<'a> {
-    github_client: &'a GitHubClient<'a, CheckRun>,
+    github_client: GitHubClient<CheckRun>,
     owner: &'a Login,
     repository: &'a RepositoryName,
 }
@@ -20,7 +20,7 @@ pub struct CreateCheckRun<'a> {
 impl<'a> CreateCheckRun<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: &'a GitHubClient<'a, CheckRun>,
+        github_client: GitHubClient<CheckRun>,
         owner: &'a Login,
         repository: &'a RepositoryName,
     ) -> Self {
@@ -35,7 +35,10 @@ impl<'a> CreateCheckRun<'a> {
 #[async_trait]
 impl<'a> Action<CreateCheckRunInput, CheckRun, CreateCheckRunError> for CreateCheckRun<'a> {
     #[tracing::instrument]
-    async fn execute(&self, input: &CreateCheckRunInput) -> Result<CheckRun, CreateCheckRunError> {
+    async fn execute(
+        &mut self,
+        input: &CreateCheckRunInput,
+    ) -> Result<CheckRun, CreateCheckRunError> {
         let url = format!(
             "/repos/{}/{}/check-runs",
             self.owner.get(),
@@ -186,13 +189,10 @@ mod tests {
                 }
             "#).create();
 
-        let github_host = GitHubHost::new(mockito::server_url());
-        let private_key =
-            PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into());
         let github_client = GitHubClient::new(
-            &github_host,
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &private_key,
+            PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
         );
         let owner = Login::new("github");
@@ -206,7 +206,7 @@ mod tests {
             completed_at: None,
         };
 
-        let check_run = CreateCheckRun::new(&github_client, &owner, &repository)
+        let check_run = CreateCheckRun::new(github_client, &owner, &repository)
             .execute(&input)
             .await
             .unwrap();

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -17,15 +17,15 @@ mod result;
 
 #[tracing::instrument]
 pub async fn get_file(
-    github_host: &GitHubHost,
+    github_host: GitHubHost,
     app_id: AppId,
-    private_key: &PrivateKey,
+    private_key: PrivateKey,
     installation: InstallationId,
     owner: &Login,
     repository: &RepositoryName,
     path: &str,
 ) -> Result<GetFileResult, GetFileError> {
-    let client: GitHubClient<GetFileResponse> =
+    let mut client: GitHubClient<GetFileResponse> =
         GitHubClient::new(github_host, app_id, private_key, installation);
 
     let url = format!(
@@ -108,9 +108,9 @@ mod tests {
             "#).create();
 
         let file = get_file(
-            &GitHubHost::new(mockito::server_url()),
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
             &Login::new("octokit"),
             &RepositoryName::new("octokit.rb"),
@@ -169,9 +169,9 @@ mod tests {
             "#).create();
 
         let error = get_file(
-            &GitHubHost::new(mockito::server_url()),
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
             &Login::new("octokit"),
             &RepositoryName::new("octokit.rb"),
@@ -212,9 +212,9 @@ mod tests {
             "#).create();
 
         let error = get_file(
-            &GitHubHost::new(mockito::server_url()),
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
             &Login::new("octokit"),
             &RepositoryName::new("octokit.rb"),
@@ -255,9 +255,9 @@ mod tests {
             "#).create();
 
         let error = get_file(
-            &GitHubHost::new(mockito::server_url()),
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
             &Login::new("jquery"),
             &RepositoryName::new("jquery"),
@@ -285,9 +285,9 @@ mod tests {
             "#).create();
 
         let error = get_file(
-            &GitHubHost::new(mockito::server_url()),
+            GitHubHost::new(mockito::server_url()),
             AppId::new(1),
-            &PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
+            PrivateKey::new(include_str!("../../../tests/fixtures/private-key.pem").into()),
             InstallationId::new(1),
             &Login::new("devxbots"),
             &RepositoryName::new("github-parts"),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -15,5 +15,5 @@ where
     Output: DeserializeOwned,
     Error: std::error::Error,
 {
-    async fn execute(&self, input: &Input) -> Result<Output, Error>;
+    async fn execute(&mut self, input: &Input) -> Result<Output, Error>;
 }

--- a/src/github/token.rs
+++ b/src/github/token.rs
@@ -1,5 +1,7 @@
+use std::marker::PhantomData;
+
 use anyhow::Context;
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use reqwest::Client;
 use secrecy::{ExposeSecret, SecretString};
@@ -9,11 +11,135 @@ use crate::error::Error;
 use crate::github::{AppId, GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 
-#[derive(Clone, Debug)]
-pub struct AppToken(SecretString);
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct App;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+pub struct Installation;
 
 #[derive(Clone, Debug)]
-pub struct InstallationToken(SecretString);
+pub struct Token<Scope> {
+    scope: PhantomData<Scope>,
+    token: SecretString,
+    expires_at: DateTime<Utc>,
+}
+
+impl<Scope> Token<Scope> {
+    pub fn get(&self) -> &str {
+        self.token.expose_secret()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct TokenFactory {
+    github_host: GitHubHost,
+    app_id: AppId,
+    private_key: PrivateKey,
+    app_token: Option<Token<App>>,
+    installation_token: Option<Token<Installation>>,
+}
+
+impl TokenFactory {
+    pub fn new(github_host: GitHubHost, app_id: AppId, private_key: PrivateKey) -> Self {
+        Self {
+            github_host,
+            app_id,
+            private_key,
+            app_token: None,
+            installation_token: None,
+        }
+    }
+
+    pub fn app(&mut self) -> Result<Token<App>, Error> {
+        let now = Utc::now();
+
+        if let Some(token) = &self.app_token {
+            if token.expires_at > now {
+                return Ok(token.clone());
+            }
+        }
+
+        let jwt = self.generate_jwt()?;
+        let token = Token {
+            scope: PhantomData,
+            token: SecretString::new(jwt),
+            expires_at: now,
+        };
+
+        self.app_token = Some(token.clone());
+
+        Ok(token)
+    }
+
+    pub async fn installation(
+        &mut self,
+        installation_id: InstallationId,
+    ) -> Result<Token<Installation>, Error> {
+        let now = Utc::now();
+
+        if let Some(token) = &self.installation_token {
+            if token.expires_at > now {
+                return Ok(token.clone());
+            }
+        }
+
+        let url = format!(
+            "{}/app/installations/{}/access_tokens",
+            self.github_host.get(),
+            installation_id
+        );
+
+        let app_token = self.app()?;
+
+        let response = Client::new()
+            .post(url)
+            .header("Authorization", format!("Bearer {}", app_token.get()))
+            .header("Accept", "application/vnd.github.v3+json")
+            .header("User-Agent", "devxbots/github-parts")
+            .send()
+            .await?;
+
+        let access_token_response = response.json::<AccessTokensResponse>().await?;
+        let token = Token {
+            scope: PhantomData,
+            token: SecretString::new(access_token_response.token),
+            expires_at: now,
+        };
+
+        self.installation_token = Some(token.clone());
+
+        Ok(token)
+    }
+
+    fn generate_jwt(&self) -> Result<String, Error> {
+        let now = Utc::now();
+
+        let issued_at = now
+            .checked_sub_signed(Duration::seconds(60))
+            .context("failed to create timestamp for iat claimn in GitHub App token")?;
+
+        let expires_at = now
+            .checked_add_signed(Duration::minutes(10))
+            .context("failed to create timestamp for exp claim in GitHub App token")?;
+
+        let claims = Claims {
+            iat: issued_at.timestamp(),
+            iss: self.app_id.get().to_string(),
+            exp: expires_at.timestamp(),
+        };
+
+        let header = Header::new(Algorithm::RS256);
+        let key =
+            EncodingKey::from_rsa_pem(self.private_key.get().as_bytes()).map_err(|error| {
+                Error::Configuration(
+                    Box::new(error),
+                    "failed to create encoding key for GitHub App token".into(),
+                )
+            })?;
+
+        Ok(encode(&header, &claims, &key).context("failed to encode JWT for GitHub App token")?)
+    }
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 struct Claims {
@@ -27,135 +153,110 @@ struct AccessTokensResponse {
     token: String,
 }
 
-impl AppToken {
-    pub fn new(app_id: &AppId, private_key: &PrivateKey) -> Result<Self, Error> {
-        let now = Utc::now();
-
-        let issued_at = now
-            .checked_sub_signed(Duration::seconds(60))
-            .context("failed to create timestamp for iat claimn in GitHub App token")?;
-
-        let expires_at = now
-            .checked_add_signed(Duration::minutes(10))
-            .context("failed to create timestamp for exp claim in GitHub App token")?;
-
-        let claims = Claims {
-            iat: issued_at.timestamp(),
-            iss: app_id.get().to_string(),
-            exp: expires_at.timestamp(),
-        };
-
-        let header = Header::new(Algorithm::RS256);
-        let key = EncodingKey::from_rsa_pem(private_key.get().as_bytes()).map_err(|error| {
-            Error::Configuration(
-                Box::new(error),
-                "failed to create encoding key for GitHub App token".into(),
-            )
-        })?;
-
-        let jwt =
-            encode(&header, &claims, &key).context("failed to encode JWT for GitHub App token")?;
-
-        Ok(Self(SecretString::new(jwt)))
-    }
-
-    pub fn get(&self) -> &str {
-        self.0.expose_secret()
-    }
-}
-
-impl InstallationToken {
-    pub async fn new(
-        endpoint: &GitHubHost,
-        app_token: &AppToken,
-        installation: &InstallationId,
-    ) -> Result<InstallationToken, Error> {
-        let url = format!(
-            "{}/app/installations/{}/access_tokens",
-            endpoint.get(),
-            installation
-        );
-
-        let response = Client::new()
-            .post(url)
-            .header("Authorization", format!("Bearer {}", app_token.get()))
-            .header("Accept", "application/vnd.github.v3+json")
-            .header("User-Agent", "devxbots/github-parts")
-            .send()
-            .await?;
-
-        let access_token_response = response.json::<AccessTokensResponse>().await?;
-
-        Ok(Self(SecretString::new(access_token_response.token)))
-    }
-
-    pub fn get(&self) -> &str {
-        self.0.expose_secret()
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use anyhow::Context;
-    use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-    use mockito::mock;
+    use std::marker::PhantomData;
+    use std::ops::{Add, Sub};
 
-    use crate::error::Error;
+    use chrono::{Duration, Utc};
+    use mockito::mock;
+    use secrecy::SecretString;
+
     use crate::github::{AppId, GitHubHost, PrivateKey};
     use crate::installation::InstallationId;
 
-    use super::{AppToken, Claims, InstallationToken};
+    use super::{App, Installation, Token, TokenFactory};
+
+    fn factory(
+        app_token: Option<Token<App>>,
+        installation_token: Option<Token<Installation>>,
+    ) -> TokenFactory {
+        TokenFactory {
+            github_host: GitHubHost::new(mockito::server_url()),
+            app_id: AppId::new(1),
+            private_key: PrivateKey::new(
+                include_str!("../../tests/fixtures/private-key.pem").into(),
+            ),
+            app_token,
+            installation_token,
+        }
+    }
 
     #[test]
-    fn app() -> Result<(), Error> {
-        let app_token = AppToken::new(
-            &AppId::new(1),
-            &PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
-        )?;
+    fn app_caches_token_while_it_is_not_expired() {
+        let token = Token {
+            scope: PhantomData,
+            token: SecretString::new("app".into()),
+            expires_at: Utc::now().add(Duration::minutes(10)),
+        };
+        let mut factory = factory(Some(token.clone()), None);
 
-        let token = decode::<Claims>(
-            app_token.get(),
-            &DecodingKey::from_rsa_pem(
-                include_str!("../../tests/fixtures/public-key.pem").as_bytes(),
-            )
-            .context("failed to create decoding key from public key")?,
-            &Validation::new(Algorithm::RS256),
-        );
+        let new_token = factory.app().unwrap();
 
-        assert!(token.is_ok());
-        Ok(())
+        assert_eq!(new_token.get(), token.get());
+    }
+
+    #[test]
+    fn app_generates_new_when_token_expired() {
+        let token = Token {
+            scope: PhantomData,
+            token: SecretString::new("app".into()),
+            expires_at: Utc::now().sub(Duration::minutes(10)),
+        };
+        let mut factory = factory(Some(token.clone()), None);
+
+        let new_token = factory.app().unwrap();
+
+        assert_ne!(new_token.get(), token.get());
     }
 
     #[tokio::test]
-    async fn installation_token() -> Result<(), Error> {
+    async fn installation_caches_token_while_it_is_not_expired() {
+        let token = Token {
+            scope: PhantomData,
+            token: SecretString::new("installation".into()),
+            expires_at: Utc::now().add(Duration::minutes(10)),
+        };
+        let mut factory = factory(None, Some(token.clone()));
+
+        let new_token = factory.installation(InstallationId::new(1)).await.unwrap();
+
+        assert_eq!(new_token.get(), token.get());
+    }
+
+    #[tokio::test]
+    async fn installation_requests_new_when_token_expired() {
         let _mock = mock("POST", "/app/installations/1/access_tokens")
             .with_status(200)
             .with_body(r#"{ "token": "ghs_16C7e42F292c6912E7710c838347Ae178B4a" }"#)
             .create();
 
-        let github_host = GitHubHost::new(mockito::server_url());
-        let app_token = AppToken::new(
-            &AppId::new(1),
-            &PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
-        )?;
-        let installation_id = InstallationId::new(1);
+        let app_token = Token {
+            scope: PhantomData,
+            token: SecretString::new("app".into()),
+            expires_at: Utc::now().sub(Duration::minutes(10)),
+        };
+        let installation_token = Token {
+            scope: PhantomData,
+            token: SecretString::new("installation".into()),
+            expires_at: Utc::now().add(Duration::minutes(10)),
+        };
+        let mut factory = factory(Some(app_token.clone()), Some(installation_token));
 
-        let installation_token =
-            InstallationToken::new(&github_host, &app_token, &installation_id).await;
+        let new_token = factory.installation(InstallationId::new(1)).await.unwrap();
 
-        assert!(installation_token.is_ok());
-        Ok(())
+        assert_ne!(new_token.get(), app_token.get());
     }
 
     #[test]
     fn trait_send() {
         fn assert_send<T: Send>() {}
-        assert_send::<AppToken>();
+        assert_send::<Token<App>>();
     }
 
     #[test]
     fn trait_sync() {
         fn assert_sync<T: Sync>() {}
-        assert_sync::<AppToken>();
+        assert_sync::<Token<App>>();
     }
 }


### PR DESCRIPTION
The GitHub client has been refactored to cache its tokens as long as they are valid. Once a token expires, it is recreated and cached again. This reduces the number of outgoing requests to the GitHub API by half, since each request always requested its own installation token.

The client now maintains an internal token factory, which required mutability to cache the tokens. This also required a change to the `Action` trait, which might turn out to be either good or bad. We consider this only the first of many changes to the public interface of both the client and the action trait, which will change as we learn more about the domain and their usage.