### PR TITLE
Pass GitHub Client by reference

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -10,9 +10,9 @@ use crate::git::HeadSha;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CreateCheckRun<'a> {
-    github_client: GitHubClient<CheckRun>,
+    github_client: &'a mut GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
 }
@@ -20,7 +20,7 @@ pub struct CreateCheckRun<'a> {
 impl<'a> CreateCheckRun<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: GitHubClient<CheckRun>,
+        github_client: &'a mut GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
     ) -> Self {
@@ -189,7 +189,7 @@ mod tests {
                 }
             "#).create();
 
-        let github_client = GitHubClient::new(
+        let mut github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -206,7 +206,7 @@ mod tests {
             completed_at: None,
         };
 
-        let check_run = CreateCheckRun::new(github_client, &owner, &repository)
+        let check_run = CreateCheckRun::new(&mut github_client, &owner, &repository)
             .execute(&input)
             .await
             .unwrap();

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -25,8 +25,7 @@ pub async fn get_file(
     repository: &RepositoryName,
     path: &str,
 ) -> Result<GetFileResult, GetFileError> {
-    let mut client: GitHubClient<GetFileResponse> =
-        GitHubClient::new(github_host, app_id, private_key, installation);
+    let mut client = GitHubClient::new(github_host, app_id, private_key, installation);
 
     let url = format!(
         "/repos/{}/{}/contents/{}",

--- a/src/action/list_check_runs.rs
+++ b/src/action/list_check_runs.rs
@@ -9,9 +9,9 @@ use crate::check_suite::CheckSuiteId;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ListCheckRuns<'a> {
-    github_client: GitHubClient<CheckRun>,
+    github_client: &'a mut GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
 }
@@ -19,7 +19,7 @@ pub struct ListCheckRuns<'a> {
 impl<'a> ListCheckRuns<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: GitHubClient<CheckRun>,
+        github_client: &'a mut GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
     ) -> Self {
@@ -181,7 +181,7 @@ mod tests {
                 }
             "#).create();
 
-        let github_client = GitHubClient::new(
+        let mut github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -190,7 +190,7 @@ mod tests {
         let owner = Login::new("github");
         let repository = RepositoryName::new("hello-world");
 
-        let check_runs = ListCheckRuns::new(github_client, &owner, &repository)
+        let check_runs = ListCheckRuns::new(&mut github_client, &owner, &repository)
             .execute(&CheckSuiteId::new(5))
             .await
             .unwrap();

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -9,9 +9,9 @@ use crate::check_run::{CheckRun, CheckRunConclusion, CheckRunId, CheckRunStatus}
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct UpdateCheckRun<'a> {
-    github_client: GitHubClient<CheckRun>,
+    github_client: &'a mut GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
     check_run_id: CheckRunId,
@@ -20,7 +20,7 @@ pub struct UpdateCheckRun<'a> {
 impl<'a> UpdateCheckRun<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: GitHubClient<CheckRun>,
+        github_client: &'a mut GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
         check_run_id: CheckRunId,
@@ -190,7 +190,7 @@ mod tests {
                 }
             "#).create();
 
-        let github_client = GitHubClient::new(
+        let mut github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -206,7 +206,7 @@ mod tests {
             completed_at: None,
         };
 
-        let check_run = UpdateCheckRun::new(github_client, &owner, &repository, check_run_id)
+        let check_run = UpdateCheckRun::new(&mut github_client, &owner, &repository, check_run_id)
             .execute(&input)
             .await
             .unwrap();


### PR DESCRIPTION
The GitHub client is passed by reference again, allowing different steps in a workflow to reuse the same client and thus token. While this makes it easy to reuse the client and token, it is not a very ergonomic solution. We might refactor this again and use a mutex or similar to achieve internal mutability in the token factory.