### PR TITLE
Change visibility of token factory to public

### DIFF
--- a/src/github/token.rs
+++ b/src/github/token.rs
@@ -31,7 +31,7 @@ impl<Scope> Token<Scope> {
 }
 
 #[derive(Clone, Debug)]
-pub(super) struct TokenFactory {
+pub struct TokenFactory {
     github_host: GitHubHost,
     app_id: AppId,
     private_key: PrivateKey,


### PR DESCRIPTION
The visibility of the token factory has been changed to public. Consumers can now use the token factory to create, cache, and refresh app and installation tokens.