### PR TITLE
Change GitHub client to interior mutability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ base64 = "0.13.0"
 chrono = { version = "0.4.19", features = ["serde"] }
 getset = "0.1.2"
 jsonwebtoken = "8.1.0"
+parking_lot = "0.12.1"
 reqwest = { version = "0.11.10", features = ["json"] }
 secrecy = "0.8.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -12,7 +12,7 @@ use crate::repository::RepositoryName;
 
 #[derive(Debug)]
 pub struct CreateCheckRun<'a> {
-    github_client: &'a mut GitHubClient,
+    github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
 }
@@ -20,7 +20,7 @@ pub struct CreateCheckRun<'a> {
 impl<'a> CreateCheckRun<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: &'a mut GitHubClient,
+        github_client: &'a GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
     ) -> Self {
@@ -189,7 +189,7 @@ mod tests {
                 }
             "#).create();
 
-        let mut github_client = GitHubClient::new(
+        let github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -206,7 +206,7 @@ mod tests {
             completed_at: None,
         };
 
-        let check_run = CreateCheckRun::new(&mut github_client, &owner, &repository)
+        let check_run = CreateCheckRun::new(&github_client, &owner, &repository)
             .execute(&input)
             .await
             .unwrap();

--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -25,7 +25,7 @@ pub async fn get_file(
     repository: &RepositoryName,
     path: &str,
 ) -> Result<GetFileResult, GetFileError> {
-    let mut client = GitHubClient::new(github_host, app_id, private_key, installation);
+    let client = GitHubClient::new(github_host, app_id, private_key, installation);
 
     let url = format!(
         "/repos/{}/{}/contents/{}",

--- a/src/action/list_check_runs.rs
+++ b/src/action/list_check_runs.rs
@@ -11,7 +11,7 @@ use crate::repository::RepositoryName;
 
 #[derive(Debug)]
 pub struct ListCheckRuns<'a> {
-    github_client: &'a mut GitHubClient,
+    github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
 }
@@ -19,7 +19,7 @@ pub struct ListCheckRuns<'a> {
 impl<'a> ListCheckRuns<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: &'a mut GitHubClient,
+        github_client: &'a GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
     ) -> Self {
@@ -181,7 +181,7 @@ mod tests {
                 }
             "#).create();
 
-        let mut github_client = GitHubClient::new(
+        let github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -190,7 +190,7 @@ mod tests {
         let owner = Login::new("github");
         let repository = RepositoryName::new("hello-world");
 
-        let check_runs = ListCheckRuns::new(&mut github_client, &owner, &repository)
+        let check_runs = ListCheckRuns::new(&github_client, &owner, &repository)
             .execute(&CheckSuiteId::new(5))
             .await
             .unwrap();

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -11,7 +11,7 @@ use crate::repository::RepositoryName;
 
 #[derive(Debug)]
 pub struct UpdateCheckRun<'a> {
-    github_client: &'a mut GitHubClient,
+    github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
     check_run_id: CheckRunId,
@@ -20,7 +20,7 @@ pub struct UpdateCheckRun<'a> {
 impl<'a> UpdateCheckRun<'a> {
     #[tracing::instrument]
     pub fn new(
-        github_client: &'a mut GitHubClient,
+        github_client: &'a GitHubClient,
         owner: &'a Login,
         repository: &'a RepositoryName,
         check_run_id: CheckRunId,
@@ -190,7 +190,7 @@ mod tests {
                 }
             "#).create();
 
-        let mut github_client = GitHubClient::new(
+        let github_client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -206,7 +206,7 @@ mod tests {
             completed_at: None,
         };
 
-        let check_run = UpdateCheckRun::new(&mut github_client, &owner, &repository, check_run_id)
+        let check_run = UpdateCheckRun::new(&github_client, &owner, &repository, check_run_id)
             .execute(&input)
             .await
             .unwrap();

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -48,7 +48,7 @@ impl GitHubClient {
     }
 
     #[tracing::instrument]
-    pub async fn get<T>(&mut self, endpoint: &str) -> Result<T, GitHubClientError>
+    pub async fn get<T>(&self, endpoint: &str) -> Result<T, GitHubClientError>
     where
         T: DeserializeOwned,
     {
@@ -60,7 +60,7 @@ impl GitHubClient {
 
     #[tracing::instrument(skip(body))]
     pub async fn post<T>(
-        &mut self,
+        &self,
         endpoint: &str,
         body: Option<impl Serialize>,
     ) -> Result<T, GitHubClientError>
@@ -72,7 +72,7 @@ impl GitHubClient {
 
     #[tracing::instrument(skip(body))]
     pub async fn patch<T>(
-        &mut self,
+        &self,
         endpoint: &str,
         body: Option<impl Serialize>,
     ) -> Result<T, GitHubClientError>
@@ -84,7 +84,7 @@ impl GitHubClient {
 
     #[tracing::instrument(skip(body))]
     async fn send_request<T>(
-        &mut self,
+        &self,
         method: Method,
         endpoint: &str,
         body: Option<impl Serialize>,
@@ -127,7 +127,7 @@ impl GitHubClient {
 
     #[tracing::instrument]
     pub async fn paginate<T>(
-        &mut self,
+        &self,
         method: Method,
         endpoint: &str,
         key: &str,
@@ -165,11 +165,7 @@ impl GitHubClient {
     }
 
     #[tracing::instrument]
-    async fn client(
-        &mut self,
-        method: Method,
-        url: &str,
-    ) -> Result<RequestBuilder, GitHubClientError> {
+    async fn client(&self, method: Method, url: &str) -> Result<RequestBuilder, GitHubClientError> {
         let token = self
             .token_factory
             .installation(self.installation_id)
@@ -256,7 +252,7 @@ mod tests {
             )
             .create();
 
-        let mut client = GitHubClient::new(
+        let client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),
@@ -328,7 +324,7 @@ mod tests {
             )
             .create();
 
-        let mut client = GitHubClient::new(
+        let client = GitHubClient::new(
             GitHubHost::new(mockito::server_url()),
             AppId::new(1),
             PrivateKey::new(include_str!("../../tests/fixtures/private-key.pem").into()),


### PR DESCRIPTION
The GitHub client and the token factory have been refactored to use interior mutability. This makes it easier to pass shared references around, for example when building a workflow in [devxbots/octox](https://github.com/devxbots/octox).

Because every call into the factory now requires at least one mutex to be locked, the solution is less ideal than the previous one. But the ergonomics are greatly improved, and even this solution is better than the original implementation that sent a request to GitHub's API for every token.