### PR TITLE
Create app entity and add it to check runs

### DIFF
--- a/src/action/get_file/mod.rs
+++ b/src/action/get_file/mod.rs
@@ -2,8 +2,9 @@ use anyhow::{anyhow, Context};
 
 use crate::account::Login;
 use crate::action::get_file::payload::GetFileResponse;
+use crate::github::app::AppId;
 use crate::github::client::{GitHubClient, GitHubClientError};
-use crate::github::{AppId, GitHubHost, PrivateKey};
+use crate::github::{GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 use crate::repository::RepositoryName;
 
@@ -67,7 +68,8 @@ mod tests {
     use mockito::mock;
 
     use crate::account::Login;
-    use crate::github::{AppId, GitHubHost, PrivateKey};
+    use crate::github::app::AppId;
+    use crate::github::{GitHubHost, PrivateKey};
     use crate::installation::InstallationId;
     use crate::repository::RepositoryName;
 

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::check_suite::CheckSuite;
 use crate::git::HeadSha;
+use crate::github::app::App;
 use crate::{id, name};
 
 pub use self::check_run_conclusion::CheckRunConclusion;
@@ -31,6 +32,9 @@ pub struct CheckRun {
 
     #[getset(get = "pub")]
     check_suite: CheckSuite,
+
+    #[getset(get = "pub")]
+    app: App,
 
     #[getset(get_copy = "pub")]
     status: CheckRunStatus,

--- a/src/github/app.rs
+++ b/src/github/app.rs
@@ -1,0 +1,41 @@
+use std::fmt::{Display, Formatter};
+
+use getset::{CopyGetters, Getters};
+use serde::{Deserialize, Serialize};
+
+use crate::account::Account;
+use crate::{id, name};
+
+id!(AppId);
+name!(AppName);
+
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+)]
+pub struct App {
+    #[getset(get_copy = "pub")]
+    id: AppId,
+
+    #[getset(get = "pub")]
+    name: AppName,
+
+    #[getset(get = "pub")]
+    owner: Account,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::App;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<App>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<App>();
+    }
+}

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -7,8 +7,9 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 
+use crate::github::app::AppId;
 use crate::github::token::TokenFactory;
-use crate::github::{AppId, GitHubHost, PrivateKey};
+use crate::github::{GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 
 #[derive(Clone, Debug)]
@@ -221,7 +222,8 @@ mod tests {
     use reqwest::header::HeaderValue;
     use reqwest::Method;
 
-    use crate::github::{AppId, GitHubHost, PrivateKey};
+    use crate::github::app::AppId;
+    use crate::github::{GitHubHost, PrivateKey};
     use crate::installation::InstallationId;
     use crate::repository::Repository;
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{id, name};
+use crate::name;
 
 pub use self::private_key::PrivateKey;
 pub use self::webhook_secret::WebhookSecret;
@@ -10,8 +10,8 @@ pub use self::webhook_secret::WebhookSecret;
 mod private_key;
 mod webhook_secret;
 
-id!(AppId);
 name!(GitHubHost);
 
+pub mod app;
 pub mod client;
 pub mod token;

--- a/src/github/token.rs
+++ b/src/github/token.rs
@@ -11,7 +11,8 @@ use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
-use crate::github::{AppId, GitHubHost, PrivateKey};
+use crate::github::app::AppId;
+use crate::github::{GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -188,7 +189,8 @@ mod tests {
     use parking_lot::Mutex;
     use secrecy::SecretString;
 
-    use crate::github::{AppId, GitHubHost, PrivateKey};
+    use crate::github::app::AppId;
+    use crate::github::{GitHubHost, PrivateKey};
     use crate::installation::InstallationId;
 
     use super::{App, Installation, Token, TokenFactory};

--- a/src/testing/client.rs
+++ b/src/testing/client.rs
@@ -1,5 +1,6 @@
+use crate::github::app::AppId;
 use crate::github::client::GitHubClient;
-use crate::github::{AppId, GitHubHost, PrivateKey};
+use crate::github::{GitHubHost, PrivateKey};
 use crate::installation::InstallationId;
 
 pub fn github_client() -> GitHubClient {


### PR DESCRIPTION
Check runs always provide information about the app that started them. This information is now captured in an `App` entity and part of the `CheckRun`.