### PR TITLE
Fix visibility of testing module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,5 @@ pub mod git;
 pub mod github;
 pub mod installation;
 pub mod repository;
-pub mod visibility;
-
-#[cfg(test)]
 pub mod testing;
+pub mod visibility;


### PR DESCRIPTION
The testing module has to be public (apparently) for consumers to resolve it. This might just be an issue with the IDE, but as a quick workaround we'll make the module public.