### PR TITLE
Create entity for check run output

### DIFF
--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::account::Login;
 use crate::action::Action;
-use crate::check_run::{CheckRun, CheckRunConclusion, CheckRunId, CheckRunStatus};
+use crate::check_run::{CheckRun, CheckRunConclusion, CheckRunId, CheckRunOutput, CheckRunStatus};
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
@@ -67,6 +67,8 @@ pub struct UpdateCheckRunInput {
     pub conclusion: Option<CheckRunConclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<CheckRunOutput>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -101,6 +103,7 @@ mod tests {
             status: Some(CheckRunStatus::Completed),
             conclusion: Some(CheckRunConclusion::Neutral),
             completed_at: None,
+            output: None,
         };
 
         let check_run = UpdateCheckRun::new(&github_client, &owner, &repository, check_run_id)

--- a/src/check_run/check_run_output.rs
+++ b/src/check_run/check_run_output.rs
@@ -1,0 +1,42 @@
+use std::fmt::{Display, Formatter};
+
+use getset::Getters;
+use serde::{Deserialize, Serialize};
+
+use crate::name;
+
+name!(CheckRunOutputTitle);
+name!(CheckRunOutputSummary);
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters)]
+pub struct CheckRunOutput {
+    /// The title of the check run.
+    #[getset(get = "pub")]
+    title: CheckRunOutputTitle,
+
+    /// The summary of the check run. This parameter supports Markdown.
+    #[getset(get = "pub")]
+    summary: CheckRunOutputSummary,
+
+    /// The details of the check run. This parameter supports Markdown.
+    #[getset(get = "pub")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CheckRunOutput;
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<CheckRunOutput>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<CheckRunOutput>();
+    }
+}

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -9,9 +9,11 @@ use crate::github::app::App;
 use crate::{id, name};
 
 pub use self::check_run_conclusion::CheckRunConclusion;
+pub use self::check_run_output::CheckRunOutput;
 pub use self::check_run_status::CheckRunStatus;
 
 mod check_run_conclusion;
+mod check_run_output;
 mod check_run_status;
 
 id!(CheckRunId);


### PR DESCRIPTION
GitHub Apps can provide additional information for their check runs, which is done through the output object. A new entity has been created for this object and added to both the check run as well as the update check run action.