### PR TITLE
Ensure entities have a constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ anyhow = "1.0.57"
 async-trait = "0.1.56"
 base64 = "0.13.0"
 chrono = { version = "0.4.19", features = ["serde"] }
+derive-new = "0.5.9"
 getset = "0.1.2"
 jsonwebtoken = "8.1.0"
 mockito = "0.31.0"

--- a/src/account/organization.rs
+++ b/src/account/organization.rs
@@ -1,12 +1,24 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
 use crate::account::{AccountId, Login};
 
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+    new,
 )]
 pub struct Organization {
     #[getset(get = "pub")]
@@ -14,12 +26,6 @@ pub struct Organization {
 
     #[getset(get_copy = "pub")]
     id: AccountId,
-}
-
-impl Organization {
-    pub fn new(login: Login, id: AccountId) -> Self {
-        Self { login, id }
-    }
 }
 
 impl Display for Organization {

--- a/src/account/user.rs
+++ b/src/account/user.rs
@@ -1,12 +1,24 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
 use crate::account::{AccountId, Login};
 
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+    new,
 )]
 pub struct User {
     #[getset(get = "pub")]
@@ -14,12 +26,6 @@ pub struct User {
 
     #[getset(get_copy = "pub")]
     id: AccountId,
-}
-
-impl User {
-    pub fn new(login: Login, id: AccountId) -> Self {
-        Self { login, id }
-    }
 }
 
 impl Display for User {

--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use derive_new::new;
 use serde::Serialize;
 
 use crate::account::Login;
@@ -10,26 +11,11 @@ use crate::git::HeadSha;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct CreateCheckRun<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
-}
-
-impl<'a> CreateCheckRun<'a> {
-    #[tracing::instrument]
-    pub fn new(
-        github_client: &'a GitHubClient,
-        owner: &'a Login,
-        repository: &'a RepositoryName,
-    ) -> Self {
-        Self {
-            github_client,
-            owner,
-            repository,
-        }
-    }
 }
 
 #[async_trait]

--- a/src/action/get_file/payload.rs
+++ b/src/action/get_file/payload.rs
@@ -14,7 +14,7 @@ pub enum GetFileResponse {
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
-pub enum GetFilePayload {
+pub(super) enum GetFilePayload {
     Directory,
     File(FilePayload),
     Submodule,
@@ -22,7 +22,7 @@ pub enum GetFilePayload {
 }
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize)]
-pub struct FilePayload {
+pub(super) struct FilePayload {
     encoding: FileEncoding,
     size: u64,
     name: String,

--- a/src/action/get_file/result.rs
+++ b/src/action/get_file/result.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
@@ -16,6 +17,7 @@ use serde::{Deserialize, Serialize};
     Serialize,
     CopyGetters,
     Getters,
+    new,
 )]
 pub struct GetFileResult {
     #[getset(get_copy = "pub")]

--- a/src/action/list_check_runs.rs
+++ b/src/action/list_check_runs.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use derive_new::new;
 use reqwest::Method;
 
 use crate::account::Login;
@@ -9,26 +10,11 @@ use crate::check_suite::CheckSuiteId;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct ListCheckRuns<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
-}
-
-impl<'a> ListCheckRuns<'a> {
-    #[tracing::instrument]
-    pub fn new(
-        github_client: &'a GitHubClient,
-        owner: &'a Login,
-        repository: &'a RepositoryName,
-    ) -> Self {
-        Self {
-            github_client,
-            owner,
-            repository,
-        }
-    }
 }
 
 #[async_trait]

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use derive_new::new;
 use serde::Serialize;
 
 use crate::account::Login;
@@ -9,29 +10,12 @@ use crate::check_run::{CheckRun, CheckRunConclusion, CheckRunId, CheckRunOutput,
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
 
-#[derive(Debug)]
+#[derive(Debug, new)]
 pub struct UpdateCheckRun<'a> {
     github_client: &'a GitHubClient,
     owner: &'a Login,
     repository: &'a RepositoryName,
     check_run_id: CheckRunId,
-}
-
-impl<'a> UpdateCheckRun<'a> {
-    #[tracing::instrument]
-    pub fn new(
-        github_client: &'a GitHubClient,
-        owner: &'a Login,
-        repository: &'a RepositoryName,
-        check_run_id: CheckRunId,
-    ) -> Self {
-        Self {
-            github_client,
-            owner,
-            repository,
-            check_run_id,
-        }
-    }
 }
 
 #[async_trait]
@@ -59,16 +43,16 @@ impl<'a> Action<UpdateCheckRunInput, CheckRun, UpdateCheckRunError> for UpdateCh
 }
 
 // TODO: Pass by reference, not by value (e.g. &HeadSha)
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, new)]
 pub struct UpdateCheckRunInput {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<CheckRunStatus>,
+    status: Option<CheckRunStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub conclusion: Option<CheckRunConclusion>,
+    conclusion: Option<CheckRunConclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub completed_at: Option<DateTime<Utc>>,
+    completed_at: Option<DateTime<Utc>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub output: Option<CheckRunOutput>,
+    output: Option<CheckRunOutput>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/check_run/check_run_output.rs
+++ b/src/check_run/check_run_output.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
@@ -8,7 +9,9 @@ use crate::name;
 name!(CheckRunOutputTitle);
 name!(CheckRunOutputSummary);
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters)]
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters, new,
+)]
 pub struct CheckRunOutput {
     /// The title of the check run.
     #[getset(get = "pub")]

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +21,18 @@ id!(CheckRunId);
 name!(CheckRunName);
 
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+    new,
 )]
 pub struct CheckRun {
     #[getset(get_copy = "pub")]

--- a/src/check_suite/mod.rs
+++ b/src/check_suite/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::CopyGetters;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,18 @@ use crate::id;
 id!(CheckSuiteId);
 
 #[derive(
-    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    new,
 )]
 pub struct CheckSuite {
     #[getset(get_copy = "pub")]

--- a/src/event/check_run/mod.rs
+++ b/src/event/check_run/mod.rs
@@ -1,3 +1,4 @@
+use derive_new::new;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +11,9 @@ pub use self::action::Action;
 
 mod action;
 
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters)]
+#[derive(
+    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, Getters, new,
+)]
 pub struct CheckRunEvent {
     #[getset(get = "pub")]
     action: Action,
@@ -29,26 +32,6 @@ pub struct CheckRunEvent {
 
     #[getset(get = "pub")]
     sender: Account,
-}
-
-impl CheckRunEvent {
-    pub fn new(
-        action: Action,
-        check_run: CheckRun,
-        repository: Repository,
-        organization: Option<Organization>,
-        installation: Option<Installation>,
-        sender: Account,
-    ) -> Self {
-        Self {
-            action,
-            check_run,
-            repository,
-            organization,
-            installation,
-            sender,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/github/app.rs
+++ b/src/github/app.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
@@ -10,7 +11,18 @@ id!(AppId);
 name!(AppName);
 
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+    new,
 )]
 pub struct App {
     #[getset(get_copy = "pub")]

--- a/src/installation/mod.rs
+++ b/src/installation/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::CopyGetters;
 use serde::{Deserialize, Serialize};
 
@@ -8,17 +9,22 @@ use crate::id;
 id!(InstallationId);
 
 #[derive(
-    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters,
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    new,
 )]
 pub struct Installation {
     #[getset(get_copy = "pub")]
     id: InstallationId,
-}
-
-impl Installation {
-    pub fn new(id: InstallationId) -> Self {
-        Self { id }
-    }
 }
 
 impl Display for Installation {

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use derive_new::new;
 use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +12,18 @@ id!(RepositoryId);
 name!(RepositoryName);
 
 #[derive(
-    Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Deserialize, Serialize, CopyGetters, Getters,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Debug,
+    Deserialize,
+    Serialize,
+    CopyGetters,
+    Getters,
+    new,
 )]
 pub struct Repository {
     #[getset(get_copy = "pub")]
@@ -31,22 +43,6 @@ pub struct Repository {
 }
 
 impl Repository {
-    pub fn new(
-        id: RepositoryId,
-        name: RepositoryName,
-        description: Option<String>,
-        owner: Account,
-        visibility: Visibility,
-    ) -> Self {
-        Self {
-            id,
-            name,
-            description,
-            owner,
-            visibility,
-        }
-    }
-
     pub fn full_name(&self) -> String {
         format!("{}/{}", self.owner.login(), self.name())
     }


### PR DESCRIPTION
A constructor was added to all entities that did not have one yet. The constructor is derived through a macro and simply contains a parameter for every field of the struct.