### PR TITLE
Make title and summary for check run output public

### DIFF
--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -10,7 +10,7 @@ use crate::github::app::App;
 use crate::{id, name};
 
 pub use self::check_run_conclusion::CheckRunConclusion;
-pub use self::check_run_output::CheckRunOutput;
+pub use self::check_run_output::{CheckRunOutput, CheckRunOutputSummary, CheckRunOutputTitle};
 pub use self::check_run_status::CheckRunStatus;
 
 mod check_run_conclusion;


### PR DESCRIPTION
The title and summary for a check run were not included in the public interface of the crate, and thus consumers were not able to construct it.