### PR TITLE
Change mutability of action trait

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -21,10 +21,7 @@ pub struct CreateCheckRun<'a> {
 #[async_trait]
 impl<'a> Action<CreateCheckRunInput, CheckRun, CreateCheckRunError> for CreateCheckRun<'a> {
     #[tracing::instrument]
-    async fn execute(
-        &mut self,
-        input: &CreateCheckRunInput,
-    ) -> Result<CheckRun, CreateCheckRunError> {
+    async fn execute(&self, input: &CreateCheckRunInput) -> Result<CheckRun, CreateCheckRunError> {
         let url = format!(
             "/repos/{}/{}/check-runs",
             self.owner.get(),

--- a/src/action/list_check_runs.rs
+++ b/src/action/list_check_runs.rs
@@ -21,7 +21,7 @@ pub struct ListCheckRuns<'a> {
 impl<'a> Action<CheckSuiteId, Vec<CheckRun>, ListCheckRunsError> for ListCheckRuns<'a> {
     #[tracing::instrument]
     async fn execute(
-        &mut self,
+        &self,
         check_suite_id: &CheckSuiteId,
     ) -> Result<Vec<CheckRun>, ListCheckRunsError> {
         let url = format!(

--- a/src/action/list_check_suites.rs
+++ b/src/action/list_check_suites.rs
@@ -20,7 +20,7 @@ pub struct ListCheckSuites<'a> {
 #[async_trait]
 impl<'a> Action<HeadSha, Vec<CheckSuite>, ListCheckRunsError> for ListCheckSuites<'a> {
     #[tracing::instrument]
-    async fn execute(&mut self, head_sha: &HeadSha) -> Result<Vec<CheckSuite>, ListCheckRunsError> {
+    async fn execute(&self, head_sha: &HeadSha) -> Result<Vec<CheckSuite>, ListCheckRunsError> {
         let url = format!(
             "/repos/{}/{}/commits/{}/check-suites",
             self.owner.get(),

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -16,5 +16,5 @@ where
     Output: DeserializeOwned,
     Error: std::error::Error,
 {
-    async fn execute(&mut self, input: &Input) -> Result<Output, Error>;
+    async fn execute(&self, input: &Input) -> Result<Output, Error>;
 }

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -21,10 +21,7 @@ pub struct UpdateCheckRun<'a> {
 #[async_trait]
 impl<'a> Action<UpdateCheckRunInput, CheckRun, UpdateCheckRunError> for UpdateCheckRun<'a> {
     #[tracing::instrument]
-    async fn execute(
-        &mut self,
-        input: &UpdateCheckRunInput,
-    ) -> Result<CheckRun, UpdateCheckRunError> {
+    async fn execute(&self, input: &UpdateCheckRunInput) -> Result<CheckRun, UpdateCheckRunError> {
         let url = format!(
             "/repos/{}/{}/check-runs/{}",
             self.owner.get(),


### PR DESCRIPTION
The trait that defines an action still required a mutable reference to `self`, which has historic reasons. After rewriting the GitHub client to use interior mutability in #53, the action does not need a mutable reference anymore.