### PR TITLE
Change action trait to consume input

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -21,7 +21,7 @@ pub struct CreateCheckRun<'a> {
 #[async_trait]
 impl<'a> Action<CreateCheckRunInput, CheckRun, CreateCheckRunError> for CreateCheckRun<'a> {
     #[tracing::instrument]
-    async fn execute(&self, input: &CreateCheckRunInput) -> Result<CheckRun, CreateCheckRunError> {
+    async fn execute(&self, input: CreateCheckRunInput) -> Result<CheckRun, CreateCheckRunError> {
         let url = format!(
             "/repos/{}/{}/check-runs",
             self.owner.get(),
@@ -87,7 +87,7 @@ mod tests {
         };
 
         let check_run = CreateCheckRun::new(&github_client, &owner, &repository)
-            .execute(&input)
+            .execute(input)
             .await
             .unwrap();
 

--- a/src/action/list_check_runs.rs
+++ b/src/action/list_check_runs.rs
@@ -22,7 +22,7 @@ impl<'a> Action<CheckSuiteId, Vec<CheckRun>, ListCheckRunsError> for ListCheckRu
     #[tracing::instrument]
     async fn execute(
         &self,
-        check_suite_id: &CheckSuiteId,
+        check_suite_id: CheckSuiteId,
     ) -> Result<Vec<CheckRun>, ListCheckRunsError> {
         let url = format!(
             "/repos/{}/{}/check-suites/{}/check-runs",
@@ -69,7 +69,7 @@ mod tests {
         let repository = RepositoryName::new("hello-world");
 
         let check_runs = ListCheckRuns::new(&github_client, &owner, &repository)
-            .execute(&CheckSuiteId::new(5))
+            .execute(CheckSuiteId::new(5))
             .await
             .unwrap();
 

--- a/src/action/list_check_suites.rs
+++ b/src/action/list_check_suites.rs
@@ -20,7 +20,7 @@ pub struct ListCheckSuites<'a> {
 #[async_trait]
 impl<'a> Action<HeadSha, Vec<CheckSuite>, ListCheckRunsError> for ListCheckSuites<'a> {
     #[tracing::instrument]
-    async fn execute(&self, head_sha: &HeadSha) -> Result<Vec<CheckSuite>, ListCheckRunsError> {
+    async fn execute(&self, head_sha: HeadSha) -> Result<Vec<CheckSuite>, ListCheckRunsError> {
         let url = format!(
             "/repos/{}/{}/commits/{}/check-suites",
             self.owner.get(),
@@ -66,7 +66,7 @@ mod tests {
         let repository = RepositoryName::new("hello-world");
 
         let check_runs = ListCheckSuites::new(&github_client, &owner, &repository)
-            .execute(&HeadSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"))
+            .execute(HeadSha::new("d6fde92930d4715a2b49857d24b940956b26d2d3"))
             .await
             .unwrap();
 

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -16,5 +16,5 @@ where
     Output: DeserializeOwned,
     Error: std::error::Error,
 {
-    async fn execute(&self, input: &Input) -> Result<Output, Error>;
+    async fn execute(&self, input: Input) -> Result<Output, Error>;
 }

--- a/src/action/update_check_run.rs
+++ b/src/action/update_check_run.rs
@@ -21,7 +21,7 @@ pub struct UpdateCheckRun<'a> {
 #[async_trait]
 impl<'a> Action<UpdateCheckRunInput, CheckRun, UpdateCheckRunError> for UpdateCheckRun<'a> {
     #[tracing::instrument]
-    async fn execute(&self, input: &UpdateCheckRunInput) -> Result<CheckRun, UpdateCheckRunError> {
+    async fn execute(&self, input: UpdateCheckRunInput) -> Result<CheckRun, UpdateCheckRunError> {
         let url = format!(
             "/repos/{}/{}/check-runs/{}",
             self.owner.get(),
@@ -88,7 +88,7 @@ mod tests {
         };
 
         let check_run = UpdateCheckRun::new(&github_client, &owner, &repository, check_run_id)
-            .execute(&input)
+            .execute(input)
             .await
             .unwrap();
 


### PR DESCRIPTION
The input to an action is now passed by value and no longer by reference. While this might occasionally require a copy, it ensures that actions can be run in parallel.