### PR TITLE
Add optional output when creating check run

### DIFF
--- a/src/action/create_check_run.rs
+++ b/src/action/create_check_run.rs
@@ -6,7 +6,9 @@ use serde::Serialize;
 
 use crate::account::Login;
 use crate::action::Action;
-use crate::check_run::{CheckRun, CheckRunConclusion, CheckRunName, CheckRunStatus};
+use crate::check_run::{
+    CheckRun, CheckRunConclusion, CheckRunName, CheckRunOutput, CheckRunStatus,
+};
 use crate::git::HeadSha;
 use crate::github::client::GitHubClient;
 use crate::repository::RepositoryName;
@@ -49,6 +51,8 @@ pub struct CreateCheckRunInput {
     pub conclusion: Option<CheckRunConclusion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output: Option<CheckRunOutput>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -84,6 +88,7 @@ mod tests {
             status: Some(CheckRunStatus::InProgress),
             conclusion: None,
             completed_at: None,
+            output: None,
         };
 
         let check_run = CreateCheckRun::new(&github_client, &owner, &repository)


### PR DESCRIPTION
The action to create a check run has been modified to optionally accept an output object. This can be useful when the check run is created in the `completed` state.