### PR TITLE
Add HTML URL to check runs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0.31"
 tracing = "0.1.35"
+url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "0.31.0"

--- a/src/check_run/mod.rs
+++ b/src/check_run/mod.rs
@@ -20,6 +20,8 @@ mod check_run_status;
 id!(CheckRunId);
 name!(CheckRunName);
 
+// TODO: Refactor instantiation to avoid constructor with too many arguments
+#[allow(clippy::too_many_arguments)]
 #[derive(
     Clone,
     Eq,
@@ -55,6 +57,9 @@ pub struct CheckRun {
 
     #[getset(get_copy = "pub")]
     conclusion: Option<CheckRunConclusion>,
+
+    #[getset(get = "pub")]
+    html_url: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The data type for check runs has been extended with the HTML URL field.
The URL can be used to direct users to the web interface for the check
run.